### PR TITLE
feat: refresh token 발급 추가 및 logintokenDto class에서 record로 변경 #16

### DIFF
--- a/api/member/build.gradle
+++ b/api/member/build.gradle
@@ -14,6 +14,8 @@ dependencies {
     implementation project(":core:infra")
     implementation project(":core:security")
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-security"
 }

--- a/api/member/src/main/java/com/backtothefuture/member/controller/MemberController.java
+++ b/api/member/src/main/java/com/backtothefuture/member/controller/MemberController.java
@@ -17,6 +17,7 @@ import com.backtothefuture.member.dto.request.MemberRegisterDto;
 import com.backtothefuture.member.dto.response.LoginTokenDto;
 import com.backtothefuture.member.service.MemberService;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,10 +30,8 @@ public class MemberController {
 
 	@PostMapping("/login")
 	public ResponseEntity<BfResponse<?>> login(
-		@Valid @RequestBody MemberLoginDto memberLoginDto, HttpServletResponse response) {
-		LoginTokenDto loginTokenDto = memberService.login(memberLoginDto);
-
-		return ResponseEntity.ok(new BfResponse<>(loginTokenDto));
+		@Valid @RequestBody MemberLoginDto memberLoginDto) {
+		return ResponseEntity.ok(new BfResponse<>(memberService.login(memberLoginDto)));
 	}
 
 	@PostMapping("/register")

--- a/api/member/src/main/java/com/backtothefuture/member/dto/response/LoginTokenDto.java
+++ b/api/member/src/main/java/com/backtothefuture/member/dto/response/LoginTokenDto.java
@@ -1,17 +1,7 @@
 package com.backtothefuture.member.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@Builder @AllArgsConstructor @NoArgsConstructor
-public class LoginTokenDto {
-	private String accessToken;
-
-	@JsonIgnore
-	private String refreshToken;
+public record LoginTokenDto(
+	String accessToken,
+	String refreshToken
+) {
 }

--- a/api/member/src/main/java/com/backtothefuture/member/service/MemberService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/MemberService.java
@@ -10,6 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.backtothefuture.domain.common.repository.RedisRepository;
 import com.backtothefuture.domain.common.util.ConvertUtil;
 import com.backtothefuture.domain.member.Member;
 import com.backtothefuture.domain.member.repository.MemberRepository;
@@ -31,6 +32,7 @@ public class MemberService {
 	private final PasswordEncoder passwordEncoder;
 	private final AuthenticationManager authenticationManager;
 	private final JwtProvider jwtProvider;
+	private final RedisRepository redisRepository;
 
 	/**
 	 * 로그인
@@ -50,12 +52,10 @@ public class MemberService {
 		String accessToken = jwtProvider.createAccessToken(userDetail);
 		String refreshToken = jwtProvider.createRefreshToken();
 
-		LoginTokenDto loginTokenDto = LoginTokenDto.builder()
-			.accessToken(accessToken)
-			.refreshToken(refreshToken)
-			.build();
+		LoginTokenDto loginTokenDto = new LoginTokenDto(accessToken, refreshToken);
 
-		// redis 토큰 정보 저장 로직 추가해야 함
+		// redis 토큰 정보 저장
+		redisRepository.saveToken(userDetail.getId(), refreshToken);
 
 		return loginTokenDto;
 	}

--- a/api/member/src/main/resources/application.yml
+++ b/api/member/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    include: infra, security
+    include: domain, infra, security
     active: dev
   jpa:
     open-in-view: false # view, Controller 단에서 Lazy를 사용하지 않음

--- a/api/member/src/test/java/com/backtothefuture/member/controller/MemberControllerTest.java
+++ b/api/member/src/test/java/com/backtothefuture/member/controller/MemberControllerTest.java
@@ -103,10 +103,7 @@ class MemberControllerTest {
         loginMap.put("password", "123456");
 
         // 로그인 성공 시 반환할 토큰 설정
-        LoginTokenDto loginTokenDto = LoginTokenDto.builder()
-                .accessToken("access token")
-                .refreshToken("resfresh token")
-                .build();
+        LoginTokenDto loginTokenDto = new LoginTokenDto("access token", "resfresh token");
 
         // memberService의 login 메서드가 호출될 때 loginTokenDto를 반환하도록 설정
         when(memberService.login(any())).thenReturn(loginTokenDto);

--- a/core/domain/build.gradle
+++ b/core/domain/build.gradle
@@ -6,4 +6,6 @@ bootJar { enabled = false }
 jar { enabled = true }
 
 dependencies {
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/DomainConfig.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/DomainConfig.java
@@ -3,11 +3,13 @@ package com.backtothefuture.domain;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
 @EnableTransactionManagement
 @EntityScan("com.backtothefuture.domain")
 @EnableJpaRepositories("com.backtothefuture.domain")
+@EnableRedisRepositories("com.backtothefuture.domain")
 public class DomainConfig {
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/repository/RedisRepository.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/repository/RedisRepository.java
@@ -1,0 +1,29 @@
+package com.backtothefuture.domain.common.repository;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisRepository {
+	@Value("${jwt.refresh-expiration-seconds}")
+	private int refreshExp;
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	/**
+	 * refresh token 저장
+	 */
+	public void saveToken(Long memberId, String refreshToken) {
+		ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+		Duration expireDuration = Duration.ofSeconds(refreshExp);
+		valueOperations.set(String.valueOf(memberId), Map.of("refreshToken", refreshToken), expireDuration);
+	}
+}

--- a/core/domain/src/main/resources/application-domain.yml
+++ b/core/domain/src/main/resources/application-domain.yml
@@ -1,0 +1,2 @@
+jwt:
+  refresh-expiration-seconds: 36000 # 리프래쉬 토큰 만료시간: 10시간

--- a/core/infra/src/main/java/com/backtothefuture/infra/config/QuerydslConfig.java
+++ b/core/infra/src/main/java/com/backtothefuture/infra/config/QuerydslConfig.java
@@ -1,4 +1,4 @@
-package com.backtotheture.infra.config;
+package com.backtothefuture.infra.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/core/infra/src/main/java/com/backtothefuture/infra/config/RedisConfig.java
+++ b/core/infra/src/main/java/com/backtothefuture/infra/config/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.backtotheture.infra.config;
+package com.backtothefuture.infra.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
## 📝 작업 내용
 - 로그인 시 반환할때 refresh token값도 반환하도록 추가했습니다.

## 💬 ETC.
 - loginTokenDto class -> record로 수정했습니다.
 - 앱 애플리케이션이므로 http-only 쿠키 설정을 하지 않았습니다.
 - redis에 memberId를 키값으로 refreshToken값을 저장합니다.

## #️⃣ 연관된 이슈
resolve: #16 