### PR TITLE
카카오 소셜 로그인(OAuth 2.0) 개발

### DIFF
--- a/api/member/build.gradle
+++ b/api/member/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-security"
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 openapi3 {

--- a/api/member/src/main/java/com/backtothefuture/member/controller/MemberController.java
+++ b/api/member/src/main/java/com/backtothefuture/member/controller/MemberController.java
@@ -2,8 +2,14 @@ package com.backtothefuture.member.controller;
 
 import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.*;
 
+import com.backtothefuture.domain.common.enums.OAuthErrorCode;
+import com.backtothefuture.domain.member.enums.ProviderType;
+import com.backtothefuture.member.dto.request.OAuthLoginDto;
+import com.backtothefuture.member.exception.OAuthException;
+import com.backtothefuture.member.service.OAuthService;
 import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,7 +32,10 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/member")
 public class MemberController {
 	private final MemberService memberService;
-
+	@Qualifier("kakaoOAuthService")
+	private final OAuthService kakaoOAuthService;
+	@Qualifier("naverOAuthService")
+	private final OAuthService naverOAuthService;
 	@PostMapping("/login")
 	public ResponseEntity<BfResponse<?>> login(
 		@Valid @RequestBody MemberLoginDto memberLoginDto, HttpServletResponse response) {
@@ -42,4 +51,18 @@ public class MemberController {
 			.body(new BfResponse<>(CREATE, Map.of("id", memberService.registerMember(reqMemberDto))));
 	}
 
+	@PostMapping("/login/oauth")
+	public ResponseEntity<BfResponse<?>> oauthLogin(
+		@Valid @RequestBody OAuthLoginDto OAuthLoginDto) {
+
+		if(OAuthLoginDto.getProviderType() == ProviderType.KAKAO){ // 카카오 로그인
+			LoginTokenDto loginTokenDto = kakaoOAuthService.getUserInfoFromResourceServer(OAuthLoginDto);
+			return ResponseEntity.ok(new BfResponse<>(loginTokenDto));
+		} else if (OAuthLoginDto.getProviderType() == ProviderType.NAVER) { // 네이버 로그인
+
+		} else { // 구글 로그인
+
+		};
+		throw new OAuthException(OAuthErrorCode.NOT_MATCH_OAUTH_TYPE);
+	}
 }

--- a/api/member/src/main/java/com/backtothefuture/member/dto/request/OAuthLoginDto.java
+++ b/api/member/src/main/java/com/backtothefuture/member/dto/request/OAuthLoginDto.java
@@ -1,0 +1,40 @@
+package com.backtothefuture.member.dto.request;
+
+
+import com.backtothefuture.domain.member.enums.ProviderType;
+import com.backtothefuture.domain.member.enums.RolesType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+public class OAuthLoginDto {
+
+    @NotBlank(message = "승인 코드는 필수입니다.")
+    private String authorizationCode;
+
+    @NotBlank(message = "providerType은 필수입니다.")
+    private ProviderType providerType;
+
+    @NotBlank(message = "rolesType은 필수입니다.")
+    private RolesType rolesType;
+
+    /*
+     * 의문사항: core 패키지의 Provider에 @JsonCreator를 이용하여 dto마다 @JsonCreator를 사용하고 싶지 않은데
+     * api 패키지에 enum 패키지를 새로 만드는 것이 괜찮은지 의문 존재...
+     */
+    @JsonCreator
+    public OAuthLoginDto(
+        @JsonProperty("authorizationCode") String authorizationCode,
+        @JsonProperty("providerType") ProviderType providerType,
+        @JsonProperty("rolesType") RolesType rolesType) {
+        this.authorizationCode = authorizationCode;
+        this.providerType = providerType;
+        this.rolesType = rolesType;
+    }
+}

--- a/api/member/src/main/java/com/backtothefuture/member/dto/request/OAuthLoginDto.java
+++ b/api/member/src/main/java/com/backtothefuture/member/dto/request/OAuthLoginDto.java
@@ -6,6 +6,7 @@ import com.backtothefuture.domain.member.enums.RolesType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -18,10 +19,10 @@ public class OAuthLoginDto {
     @NotBlank(message = "승인 코드는 필수입니다.")
     private String authorizationCode;
 
-    @NotBlank(message = "providerType은 필수입니다.")
+    @NotNull(message = "providerType은 필수입니다.")
     private ProviderType providerType;
 
-    @NotBlank(message = "rolesType은 필수입니다.")
+    @NotNull(message = "rolesType은 필수입니다.")
     private RolesType rolesType;
 
     /*

--- a/api/member/src/main/java/com/backtothefuture/member/dto/response/KakaoAccessTokenDto.java
+++ b/api/member/src/main/java/com/backtothefuture/member/dto/response/KakaoAccessTokenDto.java
@@ -25,13 +25,13 @@ public class KakaoAccessTokenDto {
     private String idToken;
 
     @JsonProperty("expires_in")
-    private String expiresIn;
+    private Integer expiresIn;
 
     @JsonProperty("refresh_token")
     private String refreshToken;
 
     @JsonProperty("refresh_token_expires_in")
-    private String refreshTokenExpiresIn;
+    private Integer refreshTokenExpiresIn;
 
     @JsonProperty("scope")
     private String scope;

--- a/api/member/src/main/java/com/backtothefuture/member/dto/response/KakaoAccessTokenDto.java
+++ b/api/member/src/main/java/com/backtothefuture/member/dto/response/KakaoAccessTokenDto.java
@@ -1,0 +1,38 @@
+package com.backtothefuture.member.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(Include.NON_ABSENT)
+public class KakaoAccessTokenDto {
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("access_token")
+    private String accessToken ;
+
+    @JsonProperty("id_token")
+    private String idToken;
+
+    @JsonProperty("expires_in")
+    private String expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    private String refreshTokenExpiresIn;
+
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/api/member/src/main/java/com/backtothefuture/member/dto/response/KakaoAccount.java
+++ b/api/member/src/main/java/com/backtothefuture/member/dto/response/KakaoAccount.java
@@ -1,0 +1,23 @@
+package com.backtothefuture.member.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoAccount {
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("phone_number")
+    private String phoneNumber;
+
+
+}

--- a/api/member/src/main/java/com/backtothefuture/member/dto/response/KakaoUserInfo.java
+++ b/api/member/src/main/java/com/backtothefuture/member/dto/response/KakaoUserInfo.java
@@ -24,11 +24,12 @@ public class KakaoUserInfo {
     @JsonProperty("kakao_account")
     private KakaoAccount kakaoAccount;
 
-    public Member toEntity(OAuthLoginDto dto){
+    public Member toEntity(OAuthLoginDto dto, String randomPassword){
+
         return Member.builder()
             .authId(String.valueOf(this.authId))
             .email(this.kakaoAccount.getEmail())
-            .password("1234")
+            .password(randomPassword)
             .phoneNumber(this.kakaoAccount.getPhoneNumber())
             .name(this.kakaoAccount.getName())
             .status(StatusType.ACTIVE)

--- a/api/member/src/main/java/com/backtothefuture/member/dto/response/KakaoUserInfo.java
+++ b/api/member/src/main/java/com/backtothefuture/member/dto/response/KakaoUserInfo.java
@@ -1,0 +1,39 @@
+package com.backtothefuture.member.dto.response;
+
+
+import com.backtothefuture.domain.member.Member;
+import com.backtothefuture.domain.member.enums.StatusType;
+import com.backtothefuture.member.dto.request.OAuthLoginDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoUserInfo {
+
+    @JsonProperty("id")
+    @NotNull(message = "authId는 필수입니다.")
+    private Long authId;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    public Member toEntity(OAuthLoginDto dto){
+        return Member.builder()
+            .authId(String.valueOf(this.authId))
+            .email(this.kakaoAccount.getEmail())
+            .password("1234")
+            .phoneNumber(this.kakaoAccount.getPhoneNumber())
+            .name(this.kakaoAccount.getName())
+            .status(StatusType.ACTIVE)
+            .provider(dto.getProviderType())
+            .roles(dto.getRolesType())
+            .build();
+    }
+}

--- a/api/member/src/main/java/com/backtothefuture/member/exception/GlobalExceptionHandler.java
+++ b/api/member/src/main/java/com/backtothefuture/member/exception/GlobalExceptionHandler.java
@@ -42,4 +42,14 @@ public class GlobalExceptionHandler {
 		BaseErrorCode errorCode = ex.getErrorCode();
 		return ResponseEntity.status(errorCode.getStatus()).body(errorCode.getErrorResponse());
 	}
+
+	/**
+	 * oauth 예외 handler
+	 */
+	@ExceptionHandler(OAuthException.class)
+	protected ResponseEntity<ErrorResponse> handleWebClientException(OAuthException ex) {
+        log.warn(">>>>> OAuthException : {}", ex);
+        BaseErrorCode errorCode = ex.getErrorCode();
+		return ResponseEntity.status(errorCode.getStatus()).body(errorCode.getErrorResponse());
+	}
 }

--- a/api/member/src/main/java/com/backtothefuture/member/exception/OAuthException.java
+++ b/api/member/src/main/java/com/backtothefuture/member/exception/OAuthException.java
@@ -1,0 +1,15 @@
+package com.backtothefuture.member.exception;
+
+
+import com.backtothefuture.domain.common.enums.OAuthErrorCode;
+import lombok.Getter;
+
+@Getter
+public class OAuthException extends RuntimeException{
+    private final OAuthErrorCode errorCode;
+
+    public OAuthException(OAuthErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/api/member/src/main/java/com/backtothefuture/member/service/KakaoOAuthService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/KakaoOAuthService.java
@@ -1,0 +1,126 @@
+package com.backtothefuture.member.service;
+
+import com.backtothefuture.domain.common.enums.OAuthErrorCode;
+import com.backtothefuture.domain.common.util.ConvertUtil;
+import com.backtothefuture.domain.member.Member;
+import com.backtothefuture.domain.member.repository.MemberRepository;
+import com.backtothefuture.member.dto.request.MemberLoginDto;
+import com.backtothefuture.member.dto.request.OAuthLoginDto;
+import com.backtothefuture.member.dto.response.KakaoAccessTokenDto;
+import com.backtothefuture.member.dto.response.KakaoUserInfo;
+import com.backtothefuture.member.dto.response.LoginTokenDto;
+import com.backtothefuture.member.exception.OAuthException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+
+@Service("kakaoOAuthService")
+@RequiredArgsConstructor
+public class KakaoOAuthService implements OAuthService {
+
+    @Value("${oauth.kakao}")
+    private String clientId;
+
+    @Value("${oauth.kakao.redirect.url}")
+    private String redirectUrl;
+
+    @Value("${oauth.kakao.client.secret}")
+    private String clientSecret;
+
+    private final String contentType = "application/x-www-form-urlencoded;charset=utf-8";
+
+    private final MemberRepository memberRepository;
+
+    private final MemberService memberService;
+
+    @Override
+    public String getAccessToken(OAuthLoginDto OAuthLoginDto) {  // token 받아옴
+
+        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+
+        requestBody.add("grant_type", "authorization_code");
+        requestBody.add("client_id", clientId);
+        requestBody.add("redirect_uri", redirectUrl);
+        requestBody.add("code", OAuthLoginDto.getAuthorizationCode());
+        requestBody.add("client_secret", clientSecret);
+
+        WebClient webclient = WebClient.builder()
+            .baseUrl("https://kauth.kakao.com")
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, contentType)
+            .build();
+
+        //access token 요청
+        KakaoAccessTokenDto responseToken = webclient.post()
+            .uri(uriBuilder -> uriBuilder
+                .path("/oauth/token")
+                .queryParams(requestBody)
+                .build())
+            .exchangeToMono(response -> {
+                if (response.statusCode().equals(HttpStatus.OK)) {
+                    return response.bodyToMono(KakaoAccessTokenDto.class);
+                } else if (response.statusCode().is4xxClientError()) { // 4xx 에러 handle
+                    throw new OAuthException(OAuthErrorCode.BAD_WEBCLIENT_REQUEST);
+                } else if (response.statusCode().is5xxServerError()) { // 5xx 에러 handle
+                    throw new OAuthException(OAuthErrorCode.BAD_OUTER_SYSTEM_ERROR);
+                } else {
+                    throw new RuntimeException("webclient error"); // 그 외 에러 handle
+                }
+            }).block(); // 동기 처리
+        return responseToken.getAccessToken();
+    }
+
+    @Override
+    @Transactional
+    public LoginTokenDto getUserInfoFromResourceServer(OAuthLoginDto OAuthLoginDto) {  // 사용자 정보 받아옴
+
+        String token = getAccessToken(OAuthLoginDto);
+
+        WebClient webclient = WebClient.builder()
+            .baseUrl("https://kapi.kakao.com/v2/user/me")
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, contentType)
+            .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            .build();
+
+        //kakao resource server로 사용자 정보 요청
+        KakaoUserInfo userInfo = webclient.post()
+            .accept(MediaType.APPLICATION_JSON)
+            .exchangeToMono(response -> {
+                if (response.statusCode().equals(HttpStatus.OK)) {
+                    return response.bodyToMono(KakaoUserInfo.class);
+                } else if (response.statusCode().is4xxClientError()) { // 4xx 에러 handle
+                    throw new OAuthException(OAuthErrorCode.BAD_WEBCLIENT_REQUEST);
+                } else if (response.statusCode().is5xxServerError()) { // 5xx 에러 handle
+                    throw new OAuthException(OAuthErrorCode.BAD_OUTER_SYSTEM_ERROR);
+                } else {
+                    throw new RuntimeException("webclient error"); // 그 외 에러 handle
+                }
+            }).block();
+
+        Member member = isMember(userInfo.getAuthId());
+
+        if(member == null){ // 비회원임으로 회원가입 처리
+            Member newMember = userInfo.toEntity(OAuthLoginDto);
+            memberRepository.save(newMember);
+            MemberLoginDto memberLoginDto = ConvertUtil.toDtoOrEntity(newMember, MemberLoginDto.class);
+            return memberService.login(memberLoginDto);
+        } else { // 기존회원은 바로 로그인 처리
+            MemberLoginDto memberLoginDto = ConvertUtil.toDtoOrEntity(member, MemberLoginDto.class);
+            return memberService.login(memberLoginDto);
+        }
+    }
+
+    @Override
+    public Member isMember(Long authId) {
+
+        return memberRepository.findByAuthId(String.valueOf(authId)).orElse(null);
+
+    }
+}

--- a/api/member/src/main/java/com/backtothefuture/member/service/KakaoOAuthService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/KakaoOAuthService.java
@@ -26,7 +26,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @RequiredArgsConstructor
 public class KakaoOAuthService implements OAuthService {
 
-    @Value("${oauth.kakao}")
+    @Value("${oauth.kakao.client.id}")
     private String clientId;
 
     @Value("${oauth.kakao.redirect.url}")

--- a/api/member/src/main/java/com/backtothefuture/member/service/MemberService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/MemberService.java
@@ -32,14 +32,14 @@ public class MemberService {
 	private final AuthenticationManager authenticationManager;
 	private final JwtProvider jwtProvider;
 
-	/**
-	 * 로그인
-	 */
-	public LoginTokenDto login(MemberLoginDto memberloginDto) {
-		UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-			memberloginDto.getEmail(),
-			memberloginDto.getPassword()
-		);
+    /**
+     * 로그인, OAuth 신규 회원 로그인
+     */
+    public LoginTokenDto login(MemberLoginDto memberloginDto) {
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+            memberloginDto.getEmail(),
+            memberloginDto.getPassword()
+        );
 
 		Authentication authenticated = authenticationManager.authenticate(authentication);
 		SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/api/member/src/main/java/com/backtothefuture/member/service/MemberService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/MemberService.java
@@ -82,12 +82,35 @@ public class MemberService {
 		return memberRepository.save(member).getId();
 	}
 
-	/**
-	 * password, passwordConfirm 체크
-	 */
-	private void validatePassword(String password, String passwordConfirm) {
-		if(!password.equals(passwordConfirm)) {
-			throw new MemberException(PASSWORD_NOT_MATCHED);
-		}
+    /**
+     * password, passwordConfirm 체크
+     */
+    private void validatePassword(String password, String passwordConfirm) {
+        if (!password.equals(passwordConfirm)) {
+            throw new MemberException(PASSWORD_NOT_MATCHED);
+        }
+    }
+
+    /**
+     * OAuth 기존 회원 로그인
+     */
+    @Transactional
+    public LoginTokenDto OAuthLogin(Member member) {
+
+		UserDetailsImpl userDetail = (UserDetailsImpl) UserDetailsImpl.from(member);
+
+		// accessToken, refreshToken 생성
+		String accessToken = jwtProvider.createAccessToken(userDetail);
+		String refreshToken = jwtProvider.createRefreshToken();
+
+		LoginTokenDto loginTokenDto = LoginTokenDto.builder()
+			.accessToken(accessToken)
+			.refreshToken(refreshToken)
+			.build();
+
+		// redis 토큰 정보 저장 로직 추가해야 함
+
+		return loginTokenDto;
+
 	}
 }

--- a/api/member/src/main/java/com/backtothefuture/member/service/NaverOAuthService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/NaverOAuthService.java
@@ -1,0 +1,25 @@
+package com.backtothefuture.member.service;
+
+import com.backtothefuture.domain.member.Member;
+import com.backtothefuture.member.dto.request.OAuthLoginDto;
+import com.backtothefuture.member.dto.response.LoginTokenDto;
+import org.springframework.stereotype.Service;
+
+@Service("naverOAuthService")
+public class NaverOAuthService implements OAuthService {
+
+    @Override
+    public String getAccessToken(OAuthLoginDto oAuthLoginDto) {
+        return null;
+    }
+
+    @Override
+    public LoginTokenDto getUserInfoFromResourceServer(OAuthLoginDto OAuthLoginDto) {
+        return null;
+    }
+
+    @Override
+    public Member isMember(Long authId) {
+        return null;
+    }
+}

--- a/api/member/src/main/java/com/backtothefuture/member/service/OAuthService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/OAuthService.java
@@ -1,0 +1,14 @@
+package com.backtothefuture.member.service;
+
+import com.backtothefuture.domain.member.Member;
+import com.backtothefuture.member.dto.request.OAuthLoginDto;
+import com.backtothefuture.member.dto.response.LoginTokenDto;
+
+public interface OAuthService {
+
+    String getAccessToken(OAuthLoginDto oAuthLoginDto);
+
+    LoginTokenDto getUserInfoFromResourceServer(OAuthLoginDto OAuthLoginDto);
+
+    Member isMember(Long authId);
+}

--- a/api/member/src/main/resources/application.yml
+++ b/api/member/src/main/resources/application.yml
@@ -13,3 +13,9 @@ server:
   port: 8080
   servlet:
     context-path: /v1
+
+oauth:
+  kakao:
+    client.id: 임시 id
+    redirect.url: 임시 url
+    client.secret: 임시 secret

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/enums/OAuthErrorCode.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/enums/OAuthErrorCode.java
@@ -1,0 +1,27 @@
+package com.backtothefuture.domain.common.enums;
+
+import com.backtothefuture.domain.response.ErrorResponse;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum OAuthErrorCode implements BaseErrorCode{
+    NOT_MATCH_OAUTH_TYPE(400, "존재하지 않는 oauth 타입입니다.", HttpStatus.BAD_REQUEST),
+    BAD_WEBCLIENT_REQUEST(500,"Webclient 요청이 잘못 되었습니다.",HttpStatus.INTERNAL_SERVER_ERROR),
+    BAD_OUTER_SYSTEM_ERROR(502,"외부 시스템 에러",HttpStatus.BAD_GATEWAY);
+
+    private final int errorCode;
+    private final String errorMessage;
+    private final HttpStatus status;
+
+    OAuthErrorCode(int errorCode, String errorMessage, HttpStatus status) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.status = status;
+    }
+
+    @Override
+    public ErrorResponse getErrorResponse() {
+        return new ErrorResponse(this.errorCode, this.errorMessage);
+    }
+}

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/enums/OAuthErrorCode.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/enums/OAuthErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum OAuthErrorCode implements BaseErrorCode{
     NOT_MATCH_OAUTH_TYPE(400, "존재하지 않는 oauth 타입입니다.", HttpStatus.BAD_REQUEST),
-    BAD_WEBCLIENT_REQUEST(500,"Webclient 요청이 잘못 되었습니다.",HttpStatus.INTERNAL_SERVER_ERROR),
+    BAD_WEBCLIENT_REQUEST_IN_ACCESS_TOEKN(400,"access token요청의 Webclient 요청이 잘못 되었습니다.",HttpStatus.BAD_REQUEST),
+    BAD_WEBCLIENT_REQUEST_IN_USER_INFO(500,"사용자 정보 요청의 Webclient 요청이 잘못 되었습니다.",HttpStatus.INTERNAL_SERVER_ERROR),
     BAD_OUTER_SYSTEM_ERROR(502,"외부 시스템 에러",HttpStatus.BAD_GATEWAY);
 
     private final int errorCode;

--- a/core/domain/src/main/java/com/backtothefuture/domain/member/Member.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/member/Member.java
@@ -14,7 +14,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
@@ -23,10 +26,13 @@ import lombok.Setter;
 	@UniqueConstraint(columnNames = "email"),
 	@UniqueConstraint(columnNames = "phoneNumber")
 })
+@Builder @NoArgsConstructor @AllArgsConstructor
 public class Member extends MutableBaseEntity {
 	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "member_id")
 	private Long id;
+
+	private String authId;			// 소셜 회원 고유 번호
 
 	private String email;			// 이메일
 

--- a/core/domain/src/main/java/com/backtothefuture/domain/member/enums/ProviderType.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/member/enums/ProviderType.java
@@ -1,7 +1,21 @@
 package com.backtothefuture.domain.member.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum ProviderType {
 	KAKAO,
 	NAVER,
-	GOOGLE
+	GOOGLE;
+
+	@JsonCreator
+	public static ProviderType fromRequest(String inputString) {
+
+		for (ProviderType providerType : ProviderType.values()) {
+			if (providerType.toString().equals(inputString.toUpperCase())) {
+				return providerType;
+			}
+		}
+		return null;
+		// throw new OAuthException(); 구조로 개발에 어려움 존재
+	}
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/member/enums/RolesType.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/member/enums/RolesType.java
@@ -1,7 +1,21 @@
 package com.backtothefuture.domain.member.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum RolesType {
 	ROLE_ADMIN, // 관리자
 	ROLE_USER, // 일반 회원
-	ROLE_STORE_OWNER, // 가게 회원
+	ROLE_STORE_OWNER; // 가게 회원
+
+	@JsonCreator
+	public static RolesType fromRequest(String inputString) {
+
+		for (RolesType rolesType : RolesType.values()) {
+			if (rolesType.toString().equals(inputString.toUpperCase())) {
+				return rolesType;
+			}
+		}
+		return null;
+		// throw new OAuthException(); 구조로 개발에 어려움 존재
+	}
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/member/repository/MemberRepository.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/member/repository/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByEmail(String email);
 	boolean existsByEmail(String email);
 	boolean existsByPhoneNumber(String phoneNumber);
+
+	Optional<Member> findByAuthId(String AuthId);
 }


### PR DESCRIPTION
## 📝 작업 내용
 - OAuth 2.0을 사용한 로그인(카카오, 네이버) 중 카카오 소셜 로그인(OAuth 2.0)을 개발했습니다. 
 - 비회원인 경우 카카오 로그인 API에서 회원 가입을 진행시킨 후 토큰을 반환하도록 했습니다.

## 💬 ETC.
 - Restemplate은 deprecated 되어 Webclient을 사용하여 외부 API를 호출하였습니다.
 -  현재 카카오 애플리케이션에 테스트앱을 등록하여 비즈앱처럼 사용이 가능하고 닉네임, 프로필 사진, 카카오계정(이메일, 전화번호), 이름, 성별을 필수 동의 항목으로 설정하였습니다.
- **미흡한점**

1.  새로운 인증 코드를 매 로그인 요청마다 받아오고 그것을 이용하여 백엔드에서 구현한 access token을 발급 받아야 하는데 해당 프로세스에 대해 테스트 코드를 어떻게 작성해야 할 지 고민입니다. 이로 인해 아직 테스트 코드 + 명세서를 작성하지 못했습니다

## #️⃣ 연관된 이슈
resolve: #5 