### PR TITLE
PR(#22) 리뷰 반영

### DIFF
--- a/api/member/src/main/java/com/backtothefuture/member/annotation/EnumTypeMisMatch.java
+++ b/api/member/src/main/java/com/backtothefuture/member/annotation/EnumTypeMisMatch.java
@@ -1,0 +1,22 @@
+package com.backtothefuture.member.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {ProviderTypeValidator.class, RolesTypeValidator.class})
+public @interface EnumTypeMisMatch {
+
+    String message() default "enum mismatch error 발생!";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/api/member/src/main/java/com/backtothefuture/member/annotation/ProviderTypeValidator.java
+++ b/api/member/src/main/java/com/backtothefuture/member/annotation/ProviderTypeValidator.java
@@ -1,0 +1,36 @@
+package com.backtothefuture.member.annotation;
+
+import com.backtothefuture.domain.member.enums.ProviderType;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Arrays;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+public class ProviderTypeValidator implements
+    ConstraintValidator<EnumTypeMisMatch, ProviderType> {
+
+    @Override
+    public void initialize(EnumTypeMisMatch constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(ProviderType value, ConstraintValidatorContext context) {
+        /**
+         * provierType이 null일때와 KAKAO2처럼 일치하는 값이 없을 때, 서로 다른 message를 출력하는 방법이 있을까요?
+         */
+//        FieldError fieldError = new FieldError("providerType enum", "providerType",
+//            "providerType은 필수입니다.");
+//        BeanPropertyBindingResult providerTypeEnum = new BeanPropertyBindingResult(null,
+//            "providerType enum");
+//        providerTypeEnum.addError(fieldError);
+//        if (value == null) {
+//            throw new MethodArgumentNotValidException(null,providerTypeEnum);
+//        }
+        return Arrays.stream(ProviderType.values()).anyMatch(providerType -> providerType == value);
+
+    }
+}

--- a/api/member/src/main/java/com/backtothefuture/member/annotation/ProviderTypeValidator.java
+++ b/api/member/src/main/java/com/backtothefuture/member/annotation/ProviderTypeValidator.java
@@ -4,10 +4,7 @@ import com.backtothefuture.domain.member.enums.ProviderType;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.util.Arrays;
-import org.springframework.validation.BeanPropertyBindingResult;
-import org.springframework.validation.BindException;
-import org.springframework.validation.FieldError;
-import org.springframework.web.bind.MethodArgumentNotValidException;
+
 
 public class ProviderTypeValidator implements
     ConstraintValidator<EnumTypeMisMatch, ProviderType> {

--- a/api/member/src/main/java/com/backtothefuture/member/annotation/RolesTypeValidator.java
+++ b/api/member/src/main/java/com/backtothefuture/member/annotation/RolesTypeValidator.java
@@ -1,0 +1,19 @@
+package com.backtothefuture.member.annotation;
+
+import com.backtothefuture.domain.member.enums.RolesType;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Arrays;
+
+public class RolesTypeValidator implements ConstraintValidator<EnumTypeMisMatch, RolesType> {
+
+    @Override
+    public void initialize(EnumTypeMisMatch constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(RolesType value, ConstraintValidatorContext context) {
+        return Arrays.stream(RolesType.values()).anyMatch(rolesType -> rolesType == value);
+    }
+}

--- a/api/member/src/main/java/com/backtothefuture/member/controller/MemberController.java
+++ b/api/member/src/main/java/com/backtothefuture/member/controller/MemberController.java
@@ -23,8 +23,6 @@ import com.backtothefuture.member.dto.request.MemberRegisterDto;
 import com.backtothefuture.member.dto.response.LoginTokenDto;
 import com.backtothefuture.member.service.MemberService;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -54,10 +52,10 @@ public class MemberController {
 	public ResponseEntity<BfResponse<?>> oauthLogin(
 		@Valid @RequestBody OAuthLoginDto OAuthLoginDto) {
 
-		if(OAuthLoginDto.getProviderType() == ProviderType.KAKAO){ // 카카오 로그인
+		if(OAuthLoginDto.providerType() == ProviderType.KAKAO){ // 카카오 로그인
 			LoginTokenDto loginTokenDto = kakaoOAuthService.getUserInfoFromResourceServer(OAuthLoginDto);
 			return ResponseEntity.ok(new BfResponse<>(loginTokenDto));
-		} else if (OAuthLoginDto.getProviderType() == ProviderType.NAVER) { // 네이버 로그인
+		} else if (OAuthLoginDto.providerType() == ProviderType.NAVER) { // 네이버 로그인
 			LoginTokenDto loginTokenDto = naverOAuthService.getUserInfoFromResourceServer(OAuthLoginDto);
 			return ResponseEntity.ok(new BfResponse<>(loginTokenDto));
 		} else { // 구글 로그인

--- a/api/member/src/main/java/com/backtothefuture/member/dto/request/OAuthLoginDto.java
+++ b/api/member/src/main/java/com/backtothefuture/member/dto/request/OAuthLoginDto.java
@@ -1,47 +1,22 @@
 package com.backtothefuture.member.dto.request;
 
-
 import com.backtothefuture.domain.member.enums.ProviderType;
 import com.backtothefuture.domain.member.enums.RolesType;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.backtothefuture.member.annotation.EnumTypeMisMatch;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@Builder
-@NoArgsConstructor
-public class OAuthLoginDto {
-
+public record OAuthLoginDto(
     @NotBlank(message = "승인 코드는 필수입니다.")
-    private String authorizationCode;
+    String authorizationCode,
 
-    @NotNull(message = "providerType은 필수입니다.")
-    private ProviderType providerType;
+    @EnumTypeMisMatch(message = "요청된 값이 존재하지 않거나 일치하는 provider type이 없습니다.")
+    ProviderType providerType,
 
-    @NotNull(message = "rolesType은 필수입니다.")
-    private RolesType rolesType;
-
+    @EnumTypeMisMatch(message = "요청된 값이 존재하지 않거나 일치하는 roles type이 없습니다.")
+    RolesType rolesType,
     @Nullable
-    private String state;
+    String state
+) {
 
-    /*
-     * 의문사항: core 패키지의 Provider에 @JsonCreator를 이용하여 dto마다 @JsonCreator를 사용하고 싶지 않은데
-     * api 패키지에 enum 패키지를 새로 만드는 것이 괜찮은지 의문 존재...
-     */
-    @JsonCreator
-    public OAuthLoginDto(
-        @JsonProperty("authorizationCode") String authorizationCode,
-        @JsonProperty("providerType") ProviderType providerType,
-        @JsonProperty("rolesType") RolesType rolesType,
-        @JsonProperty("state") String state) {
-        this.authorizationCode = authorizationCode;
-        this.providerType = providerType;
-        this.rolesType = rolesType;
-        this.state = state;
-    }
 }

--- a/api/member/src/main/java/com/backtothefuture/member/dto/response/KakaoUserInfo.java
+++ b/api/member/src/main/java/com/backtothefuture/member/dto/response/KakaoUserInfo.java
@@ -11,6 +11,7 @@ public record KakaoUserInfo(
     @NotNull(message = "authId는 필수입니다.")
     Long authId,
     @JsonProperty("kakao_account")
+    @NotNull(message = "kakaoAccount는 필수입니다.")
     KakaoAccount kakaoAccount
 ) {
 

--- a/api/member/src/main/java/com/backtothefuture/member/dto/response/KakaoUserInfo.java
+++ b/api/member/src/main/java/com/backtothefuture/member/dto/response/KakaoUserInfo.java
@@ -23,8 +23,8 @@ public record KakaoUserInfo(
             .phoneNumber(this.kakaoAccount.phoneNumber())
             .name(this.kakaoAccount.name())
             .status(StatusType.ACTIVE)
-            .provider(dto.getProviderType())
-            .roles(dto.getRolesType())
+            .provider(dto.providerType())
+            .roles(dto.rolesType())
             .build();
     }
 }

--- a/api/member/src/main/java/com/backtothefuture/member/dto/response/NaverUserInfo.java
+++ b/api/member/src/main/java/com/backtothefuture/member/dto/response/NaverUserInfo.java
@@ -26,8 +26,8 @@ public record NaverUserInfo(
             .phoneNumber(this.naverResponse.phoneNumber())
             .name(this.naverResponse.name())
             .status(StatusType.ACTIVE)
-            .provider(dto.getProviderType())
-            .roles(dto.getRolesType())
+            .provider(dto.providerType())
+            .roles(dto.rolesType())
             .build();
     }
 }

--- a/api/member/src/main/java/com/backtothefuture/member/service/KakaoOAuthService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/KakaoOAuthService.java
@@ -109,7 +109,8 @@ public class KakaoOAuthService implements OAuthService {
                 }
             }).block();
 
-        Optional<Member> member = isMember(String.valueOf(userInfo.authId()));
+        Optional<Member> member = isMember(userInfo.kakaoAccount().name(),
+            userInfo.kakaoAccount().phoneNumber());
 
         if (member.isPresent()) { // 기존회원은 바로 로그인 처리
             return memberService.OAuthLogin(member.get());
@@ -130,9 +131,9 @@ public class KakaoOAuthService implements OAuthService {
     }
 
     @Override
-    public Optional<Member> isMember(String authId) {
+    public Optional<Member> isMember(String name, String phoneNumber) {
 
-        return memberRepository.findByAuthId(authId);
+        return memberRepository.findByNameAndPhoneNumber(name, phoneNumber);
 
     }
 }

--- a/api/member/src/main/java/com/backtothefuture/member/service/KakaoOAuthService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/KakaoOAuthService.java
@@ -53,7 +53,7 @@ public class KakaoOAuthService implements OAuthService {
         requestBody.add("grant_type", "authorization_code");
         requestBody.add("client_id", clientId);
         requestBody.add("redirect_uri", redirectUrl);
-        requestBody.add("code", OAuthLoginDto.getAuthorizationCode());
+        requestBody.add("code", OAuthLoginDto.authorizationCode());
         requestBody.add("client_secret", clientSecret);
 
         WebClient webclient = WebClient.builder()

--- a/api/member/src/main/java/com/backtothefuture/member/service/MemberService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/MemberService.java
@@ -108,7 +108,8 @@ public class MemberService {
 			.refreshToken(refreshToken)
 			.build();
 
-		// redis 토큰 정보 저장 로직 추가해야 함
+		// redis 토큰 정보 저장
+		redisRepository.saveToken(userDetail.getId(), refreshToken);
 
 		return loginTokenDto;
 

--- a/api/member/src/main/java/com/backtothefuture/member/service/NaverOAuthService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/NaverOAuthService.java
@@ -96,7 +96,8 @@ public class NaverOAuthService implements OAuthService {
                 }
             }).block();
 
-        Optional<Member> member = isMember(userInfo.naverResponse().authId());
+        Optional<Member> member = isMember(userInfo.naverResponse().name(),
+            userInfo.naverResponse().phoneNumber());
 
         if (member.isPresent()) {// 기존회원은 바로 로그인 처리
             return memberService.OAuthLogin(member.get());
@@ -118,9 +119,9 @@ public class NaverOAuthService implements OAuthService {
     }
 
     @Override
-    public Optional<Member> isMember(String authId) {
+    public Optional<Member> isMember(String name, String phoneNumber) {
 
-        return memberRepository.findByAuthId(authId);
+        return memberRepository.findByNameAndPhoneNumber(name, phoneNumber);
 
     }
 }

--- a/api/member/src/main/java/com/backtothefuture/member/service/NaverOAuthService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/NaverOAuthService.java
@@ -45,8 +45,8 @@ public class NaverOAuthService implements OAuthService {
         requestBody.add("grant_type", "authorization_code");
         requestBody.add("client_id", clientId);
         requestBody.add("client_secret", clientSecret);
-        requestBody.add("code", oAuthLoginDto.getAuthorizationCode());
-        requestBody.add("state", oAuthLoginDto.getState());
+        requestBody.add("code", oAuthLoginDto.authorizationCode());
+        requestBody.add("state", oAuthLoginDto.state());
 
         WebClient webclient = WebClient.builder()
             .baseUrl("https://nid.naver.com")

--- a/api/member/src/main/java/com/backtothefuture/member/service/NaverOAuthService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/NaverOAuthService.java
@@ -10,6 +10,7 @@ import com.backtothefuture.member.dto.response.LoginTokenDto;
 import com.backtothefuture.member.dto.response.NaverAccessTokenDto;
 import com.backtothefuture.member.dto.response.NaverUserInfo;
 import com.backtothefuture.member.exception.OAuthException;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -95,29 +96,31 @@ public class NaverOAuthService implements OAuthService {
                 }
             }).block();
 
-        Member member = isMember(userInfo.naverResponse().authId());
+        Optional<Member> member = isMember(userInfo.naverResponse().authId());
 
-        if (member == null) { // 비회원임으로 회원가입 처리 후 로그인 처리
-            // 회원 가입
-            // random password 생성
-            String password = UUID.randomUUID().toString().replace("-", "");
-            Member newMember = userInfo.toEntity(OAuthLoginDto, password);
-            newMember.setPassword(passwordEncoder.encode(password));
-            memberRepository.save(newMember);
-            // 로그인
-            MemberLoginDto memberLoginDto = ConvertUtil.toDtoOrEntity(newMember,
-                MemberLoginDto.class);
-            memberLoginDto.setPassword(password);
-            return memberService.login(memberLoginDto);
-        } else { // 기존회원은 바로 로그인 처리
-            return memberService.OAuthLogin(member);
+        if (member.isPresent()) {// 기존회원은 바로 로그인 처리
+            return memberService.OAuthLogin(member.get());
         }
+
+        // 비회원임으로 회원가입 처리 후 로그인 처리
+        // 회원 가입
+        // random password 생성
+        String password = UUID.randomUUID().toString().replace("-", "");
+        Member newMember = userInfo.toEntity(OAuthLoginDto, password);
+        newMember.setPassword(passwordEncoder.encode(password));
+        memberRepository.save(newMember);
+        // 로그인
+        MemberLoginDto memberLoginDto = ConvertUtil.toDtoOrEntity(newMember,
+            MemberLoginDto.class);
+        memberLoginDto.setPassword(password);
+        return memberService.login(memberLoginDto);
+
     }
 
     @Override
-    public Member isMember(String authId) {
+    public Optional<Member> isMember(String authId) {
 
-        return memberRepository.findByAuthId(authId).orElse(null);
+        return memberRepository.findByAuthId(authId);
 
     }
 }

--- a/api/member/src/main/java/com/backtothefuture/member/service/OAuthService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/OAuthService.java
@@ -11,5 +11,5 @@ public interface OAuthService {
 
     LoginTokenDto getUserInfoFromResourceServer(OAuthLoginDto OAuthLoginDto);
 
-    Optional<Member> isMember(String authId);
+    Optional<Member> isMember(String name, String phoneNumber);
 }

--- a/api/member/src/main/java/com/backtothefuture/member/service/OAuthService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/OAuthService.java
@@ -3,6 +3,7 @@ package com.backtothefuture.member.service;
 import com.backtothefuture.domain.member.Member;
 import com.backtothefuture.member.dto.request.OAuthLoginDto;
 import com.backtothefuture.member.dto.response.LoginTokenDto;
+import java.util.Optional;
 
 public interface OAuthService {
 
@@ -10,5 +11,5 @@ public interface OAuthService {
 
     LoginTokenDto getUserInfoFromResourceServer(OAuthLoginDto OAuthLoginDto);
 
-    Member isMember(String authId);
+    Optional<Member> isMember(String authId);
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/member/enums/ProviderType.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/member/enums/ProviderType.java
@@ -9,13 +9,11 @@ public enum ProviderType {
 
 	@JsonCreator
 	public static ProviderType fromRequest(String inputString) {
-
 		for (ProviderType providerType : ProviderType.values()) {
 			if (providerType.toString().equals(inputString.toUpperCase())) {
 				return providerType;
 			}
 		}
 		return null;
-		// throw new OAuthException(); 구조로 개발에 어려움 존재
 	}
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/member/enums/RolesType.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/member/enums/RolesType.java
@@ -9,13 +9,11 @@ public enum RolesType {
 
 	@JsonCreator
 	public static RolesType fromRequest(String inputString) {
-
 		for (RolesType rolesType : RolesType.values()) {
 			if (rolesType.toString().equals(inputString.toUpperCase())) {
 				return rolesType;
 			}
 		}
 		return null;
-		// throw new OAuthException(); 구조로 개발에 어려움 존재
 	}
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/member/repository/MemberRepository.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/member/repository/MemberRepository.java
@@ -7,9 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.backtothefuture.domain.member.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-	Optional<Member> findByEmail(String email);
-	boolean existsByEmail(String email);
-	boolean existsByPhoneNumber(String phoneNumber);
 
-	Optional<Member> findByAuthId(String AuthId);
+    Optional<Member> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByPhoneNumber(String phoneNumber);
+
+    Optional<Member> findByNameAndPhoneNumber(String name, String phoneNUmber);
 }


### PR DESCRIPTION
## 📝 작업 내용

 - custom annotation을 사용하여 field validation를 했습니다. 비즈니스 코드와 검증 코드를 분리하여 관심사를 분리하였습니다.

 - class type으로 존재하는 dto를 record type으로 수정했습니다.
   -  record type은 값이 불변하는 객체인데 memberLoginDto, memberRegisterDto의 경우 service layer에서 set 메소드를 호출함으로 class type으로 유지했습니다. 

- oauth 소셜 로그인 테스트 코드와 api 명세서를 작성했습니다.
  - **테스트 코드 작성이 익숙치 않아 많이 미흡합니다,, 많은 피드백,, 부탁드립니다 ㅎㅎ** 
  

## 💬 ETC.
 - **궁금한 점**
   -  하나의 custom annotation을 사용할 때,
       provierType이 null인 경우와 KAKAO2처럼 일치하는 값이 없는 경우인 2가지 경우가 존재할 때 각각의 경우 서로 다른 
       message를 출력하는 방법이 있을까요? 
       KAKAO2처럼 존재하지 않는 값이 오면 json parse 과정에서 null을 반환하여 아예 오지 않았을 때와 같은 
      annotation(@Valid)로 검증이 수행됩니다. @EnumTypeMisMatch으로 두 가지의 경우 다른 메시지를 출력하도록 구현하고 싶은데 좋은 방법이 있으면 알려주세요!
        
 - custom annotation reference
    - https://www.baeldung.com/spring-mvc-custom-validator

- spring rest docs reference
  - https://docs.spring.io/spring-restdocs/docs/current/reference/htmlsingle/
  - https://techblog.woowahan.com/2597/

## #️⃣ 연관된 이슈
resolve: #22, #31