### PR TITLE
fix: 오기입한 redis 설정 변수명 수정 #40

### DIFF
--- a/core/infra/src/main/resources/application-infra.yml
+++ b/core/infra/src/main/resources/application-infra.yml
@@ -22,7 +22,7 @@ spring:
     redis:
       # docker container 시작 시 환경 변수를 전달 받도록 한다.
       host: ${SPRING_REDIS_HOST:localhost} # 기본값을 localhost로 설정
-      port: ${SPRING_REDIS_HOST:6379} # 기본값을 6379로 설정
+      port: ${SPRING_REDIS_PORT:6379} # 기본값을 6379로 설정
 logging:
   level:
     org.hibernate:


### PR DESCRIPTION
## 📝 작업 내용
```
data.redis.port: ${SPRING_REDIS_HOST:6379} -> ${SPRING_REDIS_PORT:6379}
```
해당 오타 수정했습니다.

## 💬 ETC.


## #️⃣ 연관된 이슈
resolve: #40 