### PR TITLE
test: testcontainer 설정, pr시 테스트 설정

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,29 @@
+name: Pull Request Integration Test
+
+# dev 브랜치에 pull request 보낼 때 작동
+on:
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  build-image-and-push:
+    runs-on: ubuntu-latest
+    # 권한을 read로 제한
+    permissions:
+      contents: read
+    # jdk 17 설정
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      # gradle 설정
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3.1.0
+      # 테스트 없이 빌드
+      - name: Build with Gradle
+        run: |
+          ./gradlew -p api/member test

--- a/api/member/build.gradle
+++ b/api/member/build.gradle
@@ -9,6 +9,10 @@ bootJar { enabled = true }
 // 외부에서 의존하기 위한 jar로 생성하는 옵션, main이 없는 라이브러리에서는 true로 비활성화함
 jar { enabled = false }
 
+ext {
+    testcontainersVersion = "1.19.2"
+}
+
 dependencies {
     implementation project(":core:domain")
     implementation project(":core:infra")
@@ -19,6 +23,13 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-security"
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // testContainer
+    testImplementation "org.testcontainers:testcontainers:${testcontainersVersion}"
+    testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
+    testImplementation "org.testcontainers:mysql"
+    testImplementation 'mysql:mysql-connector-java:8.0.23'
+    testImplementation "com.redis.testcontainers:testcontainers-redis-junit:1.6.4"
 }
 
 openapi3 {

--- a/api/member/src/test/java/com/backtothefuture/member/config/BfTestConfig.java
+++ b/api/member/src/test/java/com/backtothefuture/member/config/BfTestConfig.java
@@ -1,0 +1,38 @@
+package com.backtothefuture.member.config;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class BfTestConfig {
+
+    private static final String DRIVER_CLASS_NAME = "org.testcontainers.jdbc.ContainerDatabaseDriver";
+    private static final String URL = "jdbc:tc:mysql:8.0:///test";
+    private static final String ROOT = "sa";
+    private static final String ROOT_PASSWORD = "";
+    @Container
+    static GenericContainer<?> redisContainer = new GenericContainer<>("redis:5.0.3-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", redisContainer::getHost);
+        registry.add("spring.redis.port", () -> redisContainer.getFirstMappedPort());
+    }
+
+    @Container
+    private static MySQLContainer<?> mySQLContainer = new MySQLContainer<>("mysql:8");
+
+    @DynamicPropertySource
+    public static void overrideProps(DynamicPropertyRegistry dynamicPropertyRegistry) {
+        dynamicPropertyRegistry.add("spring.datasource.driver-class-name", () -> DRIVER_CLASS_NAME);
+        dynamicPropertyRegistry.add("spring.datasource.url", () -> URL);
+        dynamicPropertyRegistry.add("spring.datasource.username", () -> ROOT);
+        dynamicPropertyRegistry.add("spring.datasource.password", () -> ROOT_PASSWORD);
+        dynamicPropertyRegistry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+    }
+}

--- a/api/member/src/test/java/com/backtothefuture/member/controller/MemberControllerTest.java
+++ b/api/member/src/test/java/com/backtothefuture/member/controller/MemberControllerTest.java
@@ -2,6 +2,7 @@ package com.backtothefuture.member.controller;
 
 import com.backtothefuture.domain.member.enums.ProviderType;
 import com.backtothefuture.domain.member.enums.RolesType;
+import com.backtothefuture.member.config.BfTestConfig;
 import com.backtothefuture.member.dto.request.OAuthLoginDto;
 import com.backtothefuture.member.dto.response.KakaoAccount;
 import com.backtothefuture.member.dto.response.KakaoUserInfo;
@@ -41,7 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(RestDocumentationExtension.class)
 @SpringBootTest
-class MemberControllerTest {
+class MemberControllerTest extends BfTestConfig {
 
     private MockMvc mockMvc;
 

--- a/core/infra/src/main/java/com/backtothefuture/infra/config/RedisConfig.java
+++ b/core/infra/src/main/java/com/backtothefuture/infra/config/RedisConfig.java
@@ -13,10 +13,10 @@ import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String host;
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private int port;
 
     @Bean


### PR DESCRIPTION
## 📝 작업 내용
- testcontainer 적용해 db, redis를 띄운 상태로 통합테스트 수행하도록 설정
- testcontainer 의존성 추가
- property 가져오는 부분 오타 수정
- github action으로 pr시 테스트 수행하도록 설정

## 💬 ETC.
- 혹시 infra > src > test > java > com > backtothefuture 이런식으로 infra의 test경로에 test container 관련 test를 위치했을때, api쪽에서 import가 가능한 방법이 있을까요?
- 테스트 관련 설정이라, src 하위에 넣는 것도 아닌 것 같아서, api 마다 추가해줘야 하는 구조로 짰는데, 혹시 더 나은 방법을 아신다면 공유 부탁드릴게요 🥲

## #️⃣ 연관된 이슈
resolve: #49 