### PR TITLE
feat: 상품 관련 api 추가, 테스트-문서화 추가

### DIFF
--- a/api/store/src/main/java/com/backtothefuture/store/controller/ProductController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/ProductController.java
@@ -8,27 +8,27 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
 import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.CREATE;
+import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.SUCCESS;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/store")
 public class ProductController {
 
     private final ProductService productService;
 
     // 상품 등록 API
     // TODO: ROLE 을 STORE_OWNER, ADMIN 제한
-    @PostMapping("/{storeId}/products")
+    @PostMapping("/store/{storeId}/products")
     public ResponseEntity<BfResponse<?>> registerProduct(
             @PathVariable("storeId") Long storeId,
             @Valid @RequestBody ProductRegisterDto productRegisterDto
@@ -37,9 +37,27 @@ public class ProductController {
                 .body(new BfResponse<>(CREATE, Map.of("product_id", productService.registerProduct(storeId, productRegisterDto))));
     }
 
+    // 상품 단건 조회 API
+    @GetMapping("/store/{storeId}/products/{productId}")
+    public ResponseEntity<BfResponse<?>> getProduct(
+            @PathVariable Long storeId,
+            @PathVariable Long productId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BfResponse<>(SUCCESS, Map.of("product", productService.getProduct(storeId, productId))));
+    }
+
+    // 모든 product 조회
+    // TODO: 정렬 기준, 페이지네이션 등 추가 ..
+    @GetMapping("/products")
+    public ResponseEntity<BfResponse<?>> getAllProducts() {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BfResponse<>(SUCCESS, Map.of("products", productService.getAllProducts())));
+    }
+
     // 상품 삭제 API
     // TODO: ROLE 을 STORE_OWNER, ADMIN 제한
-    @DeleteMapping("/{storeId}/products/{productId}")
+    @DeleteMapping("/store/{storeId}/products/{productId}")
     public ResponseEntity<BfResponse<?>> deleteProduct(
             @PathVariable("storeId") Long storeId,
             @PathVariable("productId") Long productId

--- a/api/store/src/main/java/com/backtothefuture/store/controller/ProductController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/ProductController.java
@@ -2,6 +2,7 @@ package com.backtothefuture.store.controller;
 
 import com.backtothefuture.domain.response.BfResponse;
 import com.backtothefuture.store.dto.request.ProductRegisterDto;
+import com.backtothefuture.store.dto.request.ProductUpdateDto;
 import com.backtothefuture.store.service.ProductService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -47,12 +49,24 @@ public class ProductController {
                 .body(new BfResponse<>(SUCCESS, Map.of("product", productService.getProduct(storeId, productId))));
     }
 
-    // 모든 product 조회
+    // 모든 상품 조회 API
     // TODO: 정렬 기준, 페이지네이션 등 추가 ..
     @GetMapping("/products")
     public ResponseEntity<BfResponse<?>> getAllProducts() {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new BfResponse<>(SUCCESS, Map.of("products", productService.getAllProducts())));
+    }
+
+    // 상품 수정 API
+    // TODO: ROLE 을 STORE_OWNER, ADMIN 제한
+    @PatchMapping("/store/{storeId}/products/{productId}")
+    public ResponseEntity<BfResponse<?>> updateProduct(
+            @PathVariable Long storeId,
+            @PathVariable Long productId,
+            @Valid @RequestBody ProductUpdateDto productUpdateDto
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BfResponse<>(SUCCESS, Map.of("product", productService.partialUpdateProduct(storeId, productId, productUpdateDto))));
     }
 
     // 상품 삭제 API

--- a/api/store/src/main/java/com/backtothefuture/store/controller/ProductController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/ProductController.java
@@ -21,14 +21,14 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/products")
+@RequestMapping("/store")
 public class ProductController {
 
     private final ProductService productService;
 
     // 상품 등록 API
     // TODO: ROLE 을 STORE_OWNER, ADMIN 제한
-    @PostMapping("/{storeId}")
+    @PostMapping("/{storeId}/products")
     public ResponseEntity<BfResponse<?>> registerProduct(
             @PathVariable("storeId") Long storeId,
             @Valid @RequestBody ProductRegisterDto productRegisterDto
@@ -39,7 +39,7 @@ public class ProductController {
 
     // 상품 삭제 API
     // TODO: ROLE 을 STORE_OWNER, ADMIN 제한
-    @DeleteMapping("/{storeId}/{productId}")
+    @DeleteMapping("/{storeId}/products/{productId}")
     public ResponseEntity<BfResponse<?>> deleteProduct(
             @PathVariable("storeId") Long storeId,
             @PathVariable("productId") Long productId

--- a/api/store/src/main/java/com/backtothefuture/store/dto/request/ProductUpdateDto.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/request/ProductUpdateDto.java
@@ -1,0 +1,25 @@
+package com.backtothefuture.store.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder
+public record ProductUpdateDto(
+        @Size(max = 20, message = "상품 이름은 최대 20자 이하로 입력해주세요.")
+        String name,
+
+        @Size(max = 50, message = "상품 설명은 최대 50자 이하로 입력해주세요.")
+        String description,
+
+        @Min(value = 0, message = "가격은 음수일 수 없습니다.")
+        @Max(value = 1000000, message = "최대 100만원까지 입력 가능합니다.")
+        int price,
+
+        @Min(value = 0, message = "재고는 음수일 수 없습니다.")
+        int stockQuantity, // 재고 수량, optional, default 0
+        String thumbnail // 썸네일 이미지, optional, default ""
+) {
+
+}

--- a/api/store/src/main/java/com/backtothefuture/store/dto/response/ProductResponseDto.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/response/ProductResponseDto.java
@@ -1,0 +1,14 @@
+package com.backtothefuture.store.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record ProductResponseDto(
+        Long id,                // 상품 아이디
+        String name,            // 상품 이름
+        String description,     // 상품 설명
+        int price,              // 상품 가격
+        int stockQuantity,      // 재고 수량
+        String thumbnail       // 썸네일 이미지
+) {
+}

--- a/api/store/src/main/java/com/backtothefuture/store/service/ProductService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/ProductService.java
@@ -7,6 +7,7 @@ import com.backtothefuture.domain.store.repository.StoreRepository;
 import com.backtothefuture.security.exception.CustomSecurityException;
 import com.backtothefuture.security.service.UserDetailsImpl;
 import com.backtothefuture.store.dto.request.ProductRegisterDto;
+import com.backtothefuture.store.dto.request.ProductUpdateDto;
 import com.backtothefuture.store.dto.response.ProductResponseDto;
 import com.backtothefuture.store.exception.ProductException;
 import lombok.RequiredArgsConstructor;
@@ -74,6 +75,37 @@ public class ProductService {
                         .thumbnail(product.getThumbnail())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public ProductResponseDto partialUpdateProduct(Long storeId, Long productId, ProductUpdateDto productUpdateDto) {
+        // 권한 검사
+        if (!validateIsProductOwner(storeId, productId)) {
+            throw new ProductException(FORBIDDEN_DELETE_PRODUCT);
+        }
+
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ProductException(NOT_FOUND_PRODUCT_ID));
+
+        Optional.ofNullable(productUpdateDto.name())
+                .ifPresent(product::updateName);
+        Optional.ofNullable(productUpdateDto.description())
+                .ifPresent(product::updateDescription);
+        Optional.ofNullable(productUpdateDto.price())
+                .ifPresent(product::updatePrice);
+        Optional.ofNullable(productUpdateDto.stockQuantity())
+                .ifPresent(product::updateStockQuantity);
+        Optional.ofNullable(productUpdateDto.thumbnail())
+                .ifPresent(product::updateThumbnail);
+
+        return ProductResponseDto.builder()
+                .id(product.getId())
+                .name(product.getName())
+                .description(product.getDescription())
+                .price(product.getPrice())
+                .stockQuantity(product.getStockQuantity())
+                .thumbnail(product.getThumbnail())
+                .build();
     }
 
     @Transactional

--- a/api/store/src/main/java/com/backtothefuture/store/service/ProductService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/ProductService.java
@@ -7,16 +7,19 @@ import com.backtothefuture.domain.store.repository.StoreRepository;
 import com.backtothefuture.security.exception.CustomSecurityException;
 import com.backtothefuture.security.service.UserDetailsImpl;
 import com.backtothefuture.store.dto.request.ProductRegisterDto;
+import com.backtothefuture.store.dto.response.ProductResponseDto;
 import com.backtothefuture.store.exception.ProductException;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.backtothefuture.domain.common.enums.GlobalErrorCode.CHECK_USER;
 import static com.backtothefuture.domain.common.enums.ProductErrorCode.*;
@@ -37,6 +40,40 @@ public class ProductService {
 
         Product product = ProductRegisterDto.toEntity(productRegisterDto, store);
         return productRepository.save(product).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public ProductResponseDto getProduct(Long storeId, Long productId) {
+
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ProductException(NOT_FOUND_PRODUCT_ID));
+
+        if (!storeId.equals(product.getStore().getId())) {
+            throw new ProductException(NOT_FOUND_STORE_PRODUCT_MATCH);
+        }
+
+        return ProductResponseDto.builder()
+                .id(product.getId())
+                .name(product.getName())
+                .description(product.getDescription())
+                .price(product.getPrice())
+                .stockQuantity(product.getStockQuantity())
+                .thumbnail(product.getThumbnail())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductResponseDto> getAllProducts() {
+        return productRepository.findAll().stream()
+                .map(product -> ProductResponseDto.builder()
+                        .id(product.getId())
+                        .name(product.getName())
+                        .description(product.getDescription())
+                        .price(product.getPrice())
+                        .stockQuantity(product.getStockQuantity())
+                        .thumbnail(product.getThumbnail())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/api/store/src/test/java/com/backtothefuture/store/controller/ProductControllerTest.java
+++ b/api/store/src/test/java/com/backtothefuture/store/controller/ProductControllerTest.java
@@ -65,7 +65,7 @@ class ProductControllerTest {
                 .build();
         when(productService.registerProduct(storeId, productRegisterDto)).thenReturn(1L);
 
-        this.mockMvc.perform(post("/products/{storeId}", 1)
+        this.mockMvc.perform(post("/store/{storeId}/products", 1)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(productRegisterDto))
                         .header("Authorization", "Bearer ${JWT Token}"))
@@ -104,7 +104,7 @@ class ProductControllerTest {
     @WithMockUser("USER")
     @DisplayName("상품 삭제 테스트")
     void deleteProductTest() throws Exception {
-        this.mockMvc.perform(delete("/products/{storeId}/{productId}", 1, 1)
+        this.mockMvc.perform(delete("/store/{storeId}/products/{productId}", 1, 1)
                         .header("Authorization", "Bearer ${JWT Token}"))
                 .andExpect(status().isNoContent())
                 .andDo(document("delete-product",

--- a/core/domain/src/main/java/com/backtothefuture/domain/product/Product.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/product/Product.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Getter
@@ -42,4 +43,24 @@ public class Product extends MutableBaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
     private Store store;            // 가게
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+
+    public void updatePrice(int price) {
+        this.price = price;
+    }
+
+    public void updateStockQuantity(int stockQuantity) {
+        this.stockQuantity = stockQuantity;
+    }
+
+    public void updateThumbnail(String thumbnail) {
+        this.thumbnail = thumbnail;
+    }
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/product/repository/ProductRepository.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/product/repository/ProductRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,4 +19,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     boolean existsById(Long id);
 
     Optional<Product> findById(Long id);
+
+    List<Product> findAll();
 }

--- a/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
+++ b/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
@@ -126,9 +126,10 @@ public class SpringSecurityConfig {
 	 */
 	private RequestMatcher[] AuthRequestMatchers() {
 		List<RequestMatcher> requestMatchers = List.of(
-			antMatcher(POST, "/store/register"),			// 가게 등록
+			antMatcher(POST, "/store/register"),							// 가게 등록
 			antMatcher(POST, "/store/{storeId}/products"),				// 상품 등록
-			antMatcher(DELETE, "/store/{storeId}/products/{productId}")			// 상품 삭제
+			antMatcher(DELETE, "/store/{storeId}/products/{productId}"),	// 상품 삭제
+			antMatcher(PATCH, "/store/{storeId}/products/{productId}")    // 상품 수정
 		);
 
 		return requestMatchers.toArray(RequestMatcher[]::new);

--- a/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
+++ b/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
@@ -113,7 +113,9 @@ public class SpringSecurityConfig {
 	private RequestMatcher[] permitAllRequestMatchers() {
 		List<RequestMatcher> requestMatchers = List.of(
 			antMatcher(POST,"/member/login"),			// 로그인
-			antMatcher(POST, "/member/register")		// 회원가입
+			antMatcher(POST, "/member/register"),		// 회원가입
+			antMatcher(GET, "/store/{storeId}/products/{productId}"),		// 상품 단건 조회 API
+			antMatcher(GET, "/products")									// 상품 전체 조회 API
 		);
 
 		return requestMatchers.toArray(RequestMatcher[]::new);
@@ -125,8 +127,8 @@ public class SpringSecurityConfig {
 	private RequestMatcher[] AuthRequestMatchers() {
 		List<RequestMatcher> requestMatchers = List.of(
 			antMatcher(POST, "/store/register"),			// 가게 등록
-			antMatcher(POST, "/products/**"),				// 상품 등록
-			antMatcher(DELETE, "/products/**")			// 상품 삭제
+			antMatcher(POST, "/store/{storeId}/products"),				// 상품 등록
+			antMatcher(DELETE, "/store/{storeId}/products/{productId}")			// 상품 삭제
 		);
 
 		return requestMatchers.toArray(RequestMatcher[]::new);

--- a/docs/openapi/store-openapi.yaml
+++ b/docs/openapi/store-openapi.yaml
@@ -130,8 +130,118 @@ paths:
       responses:
         "204":
           description: "204"
+    patch:
+      tags:
+      - products
+      summary: 상품 업데이트 API
+      description: 상품 업데이트 API 입니다. 업데이트 할 항목만 보내주세요.
+      operationId: update-product
+      parameters:
+      - name: storeId
+        in: path
+        description: 가게 ID
+        required: true
+        schema:
+          type: number
+      - name: productId
+        in: path
+        description: 상품 ID
+        required: true
+        schema:
+          type: number
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/[reqyest] update-product"
+            examples:
+              update-product:
+                value: "{\"name\":\"업데이트된 상품 이름\",\"description\":\"업데이트된 상품 설명\"\
+                  ,\"price\":15000,\"stockQuantity\":5,\"thumbnail\":\"업데이트된 이미지 링\
+                  크\"}"
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/[response] update-product"
+              examples:
+                update-product:
+                  value: "{\"code\":200,\"message\":\"정상 처리되었습니다.\",\"data\":{\"product\"\
+                    :{\"id\":1,\"name\":\"업데이트된 상품 이름\",\"description\":\"업데이트된 상품\
+                    \ 설명\",\"price\":15000,\"stockQuantity\":5,\"thumbnail\":\"업데이\
+                    트된 이미지 링크\"}}}"
 components:
   schemas:
+    '[response] update-product':
+      title: "[response] update-product"
+      required:
+      - code
+      - message
+      type: object
+      properties:
+        code:
+          type: number
+          description: HttpStatusCode 입니다.
+        data:
+          type: object
+          properties:
+            product:
+              required:
+              - description
+              - id
+              - name
+              - price
+              - stockQuantity
+              - thumbnail
+              type: object
+              properties:
+                thumbnail:
+                  type: string
+                  description: 썸네일 이미지 URL
+                price:
+                  type: number
+                  description: 상품 가격
+                name:
+                  type: string
+                  description: 상품 이름
+                stockQuantity:
+                  type: number
+                  description: 재고 수량
+                description:
+                  type: string
+                  description: 상품 설명
+                id:
+                  type: number
+                  description: 상품 ID
+        message:
+          type: string
+          description: 응답 메시지 입니다.
+    '[reqyest] update-product':
+      title: "[reqyest] update-product"
+      type: object
+      properties:
+        thumbnail:
+          type: string
+          description: 썸네일 이미지 입니다.
+          nullable: true
+        price:
+          type: number
+          description: 상품 가격입니다. 0 이상의 수를 입력해주세요.
+          nullable: true
+        name:
+          type: string
+          description: 상품 이름입니다.
+          nullable: true
+        stockQuantity:
+          type: number
+          description: 상품 재고입니다. 0 이상의 수를 입력해주세요.
+          nullable: true
+        description:
+          type: string
+          description: 상품 상세 설명입니다.
+          nullable: true
     '[response] get-all-products':
       title: "[response] get-all-products"
       required:

--- a/docs/openapi/store-openapi.yaml
+++ b/docs/openapi/store-openapi.yaml
@@ -7,7 +7,7 @@ servers:
 - url: http://localhost:8081/v1
 tags: []
 paths:
-  /products/{storeId}:
+  /store/{storeId}/products:
     post:
       tags:
       - products
@@ -48,7 +48,7 @@ paths:
                 register-product:
                   value: "{\"code\":201,\"message\":\"정상적으로 생성되었습니다.\",\"data\":{\"\
                     product_id\":1}}"
-  /products/{storeId}/{productId}:
+  /store/{storeId}/products/{productId}:
     delete:
       tags:
       - products

--- a/docs/openapi/store-openapi.yaml
+++ b/docs/openapi/store-openapi.yaml
@@ -7,6 +7,27 @@ servers:
 - url: http://localhost:8081/v1
 tags: []
 paths:
+  /products:
+    get:
+      tags:
+      - products
+      summary: 모든 상품 조회 API
+      description: 모든 상품 조회 API입니다.
+      operationId: get-all-products
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/[response] get-all-products"
+              examples:
+                get-all-products:
+                  value: "{\"code\":200,\"message\":\"정상 처리되었습니다.\",\"data\":{\"products\"\
+                    :[{\"id\":1,\"name\":\"상품1\",\"description\":\"상품1 설명\",\"price\"\
+                    :10000,\"stockQuantity\":10,\"thumbnail\":\"thumbnail1\"},{\"\
+                    id\":2,\"name\":\"상품2\",\"description\":\"상품2 설명\",\"price\":20000,\"\
+                    stockQuantity\":20,\"thumbnail\":\"thumbnail2\"}]}}"
   /store/{storeId}/products:
     post:
       tags:
@@ -49,6 +70,37 @@ paths:
                   value: "{\"code\":201,\"message\":\"정상적으로 생성되었습니다.\",\"data\":{\"\
                     product_id\":1}}"
   /store/{storeId}/products/{productId}:
+    get:
+      tags:
+      - products
+      summary: 상품 단건 조회 API
+      description: 상품 단건 조회 API입니다.
+      operationId: get-product-by-store
+      parameters:
+      - name: storeId
+        in: path
+        description: 가게 ID
+        required: true
+        schema:
+          type: number
+      - name: productId
+        in: path
+        description: 상품 ID
+        required: true
+        schema:
+          type: number
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/[response] get-product"
+              examples:
+                get-product-by-store:
+                  value: "{\"code\":200,\"message\":\"정상 처리되었습니다.\",\"data\":{\"product\"\
+                    :{\"id\":1,\"name\":\"상품1\",\"description\":\"상품1 설명\",\"price\"\
+                    :10000,\"stockQuantity\":10,\"thumbnail\":\"thumbnail1\"}}}"
     delete:
       tags:
       - products
@@ -80,6 +132,52 @@ paths:
           description: "204"
 components:
   schemas:
+    '[response] get-all-products':
+      title: "[response] get-all-products"
+      required:
+      - code
+      - message
+      type: object
+      properties:
+        code:
+          type: number
+          description: HttpStatusCode 입니다.
+        data:
+          type: object
+          properties:
+            products:
+              type: array
+              items:
+                required:
+                - description
+                - id
+                - name
+                - price
+                - stockQuantity
+                - thumbnail
+                type: object
+                properties:
+                  thumbnail:
+                    type: string
+                    description: 썸네일 이미지 URL
+                  price:
+                    type: number
+                    description: 상품 가격
+                  name:
+                    type: string
+                    description: 상품 이름
+                  stockQuantity:
+                    type: number
+                    description: 재고 수량
+                  description:
+                    type: string
+                    description: 상품 설명
+                  id:
+                    type: number
+                    description: 상품 ID
+        message:
+          type: string
+          description: 응답 메시지 입니다.
     '[response] product-register':
       title: "[response] product-register"
       required:
@@ -126,6 +224,50 @@ components:
         description:
           type: string
           description: 상품 상세 설명입니다.
+    '[response] get-product':
+      title: "[response] get-product"
+      required:
+      - code
+      - message
+      type: object
+      properties:
+        code:
+          type: number
+          description: HttpStatusCode 입니다.
+        data:
+          type: object
+          properties:
+            product:
+              required:
+              - description
+              - id
+              - name
+              - price
+              - stockQuantity
+              - thumbnail
+              type: object
+              properties:
+                thumbnail:
+                  type: string
+                  description: 썸네일 이미지 URL
+                price:
+                  type: number
+                  description: 상품 가격
+                name:
+                  type: string
+                  description: 상품 이름
+                stockQuantity:
+                  type: number
+                  description: 재고 수량
+                description:
+                  type: string
+                  description: 상품 설명
+                id:
+                  type: number
+                  description: 상품 ID
+        message:
+          type: string
+          description: 응답 메시지 입니다.
   securitySchemes:
     bearerAuth:
       type: http


### PR DESCRIPTION
## 📝 작업 내용
 - 상품 단건 조회 api 추가
 - 상품 전체 조회 api (정렬, 검색키워드, 페이지네이션 등 추가 및 개선이 필요함) 추가
 - 상품 업데이트 api 추가
 - 가게에 대한 상품 전체정보는 /store/{storeId}에서 상품 정보 & 가게 정보를 같이 가져오는 편이 낫다고 생각해서 제외함
   - 보통 전체 가게 목록에서 클릭 -> 가게 정보와 상품 정보를 같이 조회하기 때문
- 기타 테스트 및 문서화 코드 추가
- **security 관련**: 조회는 슬랙에서 비회원 유저도 가능하도록 하자는 이야기가 있어 전체허용으로 설정했습니다. 

## 💬 ETC.
<img width="1372" alt="image" src="https://github.com/backtothefuture-team/backtothefuture-backend/assets/67352902/deef9301-ecf6-4301-b847-1a4a7f8f68f4">

## #️⃣ 연관된 이슈
resolves: #27 