### PR TITLE
fix: @Qualifier를 인식하지 못하는 오류 해결

### DIFF
--- a/api/member/src/main/java/com/backtothefuture/member/controller/MemberController.java
+++ b/api/member/src/main/java/com/backtothefuture/member/controller/MemberController.java
@@ -30,11 +30,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/member")
 public class MemberController {
-	private final MemberService memberService;
-	// @Qualifier("kakaoOAuthService")
-	// private final OAuthService kakaoOAuthService;
-	// @Qualifier("naverOAuthService")
-	// private final OAuthService naverOAuthService;
+
+	 private final MemberService memberService;
+	 @Qualifier("kakaoOAuthService")
+	 private final OAuthService kakaoOAuthService;
+	 @Qualifier("naverOAuthService")
+	 private final OAuthService naverOAuthService;
 	@PostMapping("/login")
 	public ResponseEntity<BfResponse<?>> login(
 		@Valid @RequestBody MemberLoginDto memberLoginDto) {
@@ -48,23 +49,23 @@ public class MemberController {
 			.body(new BfResponse<>(CREATE, Map.of("id", memberService.registerMember(reqMemberDto))));
 	}
 
-	// @PostMapping("/login/oauth")
-	// public ResponseEntity<BfResponse<?>> oauthLogin(
-	// 	@Valid @RequestBody OAuthLoginDto OAuthLoginDto) {
-	//
-	// 	switch(OAuthLoginDto.providerType()){
-	// 		case KAKAO -> {
-	// 			LoginTokenDto loginTokenDto = kakaoOAuthService.getUserInfoFromResourceServer(OAuthLoginDto);
-	// 			return ResponseEntity.ok(new BfResponse<>(loginTokenDto));
-	// 		}
-	// 		case NAVER -> {
-	// 			LoginTokenDto loginTokenDto = naverOAuthService.getUserInfoFromResourceServer(OAuthLoginDto);
-	// 			return ResponseEntity.ok(new BfResponse<>(loginTokenDto));
-	// 		}
-	// 		/* google 소셜 로그인 추가 시 사용
-	// 		case GOOGLE -> {
-	// 		} */
-	// 		default -> throw new OAuthException(OAuthErrorCode.NOT_MATCH_OAUTH_TYPE);
-	// 	}
-	// }
+	 @PostMapping("/login/oauth")
+	 public ResponseEntity<BfResponse<?>> oauthLogin(
+	 	@Valid @RequestBody OAuthLoginDto OAuthLoginDto) {
+
+	 	switch(OAuthLoginDto.providerType()){
+	 		case KAKAO -> {
+	 			LoginTokenDto loginTokenDto = kakaoOAuthService.getUserInfoFromResourceServer(OAuthLoginDto);
+	 			return ResponseEntity.ok(new BfResponse<>(loginTokenDto));
+	 		}
+	 		case NAVER -> {
+	 			LoginTokenDto loginTokenDto = naverOAuthService.getUserInfoFromResourceServer(OAuthLoginDto);
+	 			return ResponseEntity.ok(new BfResponse<>(loginTokenDto));
+	 		}
+	 		/* google 소셜 로그인 추가 시 사용
+	 		case GOOGLE -> {
+	 		} */
+	 		default -> throw new OAuthException(OAuthErrorCode.NOT_MATCH_OAUTH_TYPE);
+	 	}
+	 }
 }

--- a/api/member/src/main/java/com/backtothefuture/member/service/KakaoOAuthService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/KakaoOAuthService.java
@@ -25,7 +25,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
 
 
-// @Service("kakaoOAuthService")
+@Service("kakaoOAuthService")
 @RequiredArgsConstructor
 public class KakaoOAuthService implements OAuthService {
 

--- a/api/member/src/main/java/com/backtothefuture/member/service/NaverOAuthService.java
+++ b/api/member/src/main/java/com/backtothefuture/member/service/NaverOAuthService.java
@@ -25,7 +25,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-// @Service("naverOAuthService")
+@Service("naverOAuthService")
 @RequiredArgsConstructor
 public class NaverOAuthService implements OAuthService {
 

--- a/api/member/src/main/java/lombok.config
+++ b/api/member/src/main/java/lombok.config
@@ -1,0 +1,2 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Value

--- a/api/member/src/test/java/com/backtothefuture/member/controller/MemberControllerTest.java
+++ b/api/member/src/test/java/com/backtothefuture/member/controller/MemberControllerTest.java
@@ -1,11 +1,7 @@
 package com.backtothefuture.member.controller;
 
-import com.backtothefuture.domain.member.enums.ProviderType;
-import com.backtothefuture.domain.member.enums.RolesType;
+
 import com.backtothefuture.infra.config.BfTestConfig;
-import com.backtothefuture.member.dto.request.OAuthLoginDto;
-import com.backtothefuture.member.dto.response.KakaoAccount;
-import com.backtothefuture.member.dto.response.KakaoUserInfo;
 import com.backtothefuture.member.dto.response.LoginTokenDto;
 import com.backtothefuture.member.service.KakaoOAuthService;
 import com.backtothefuture.member.service.MemberService;
@@ -49,7 +45,7 @@ class MemberControllerTest extends BfTestConfig {
     @MockBean
     private MemberService memberService;
 
-    @MockBean
+    @MockBean(name ="kakaoOAuthService")
     private KakaoOAuthService kakaoOAuthService;
 
     @Autowired

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+config.stopBubbling = true


### PR DESCRIPTION
## 📝 작업 내용
 - Lombok을 사용할 때, ` @RequiredArgsConstructor ` 와 `@Qualifier` 를 함께 사용하면 `@Qualifier`를 인지 못하는 오류가 존재하여 lombok.config파일을 생성하고 
`lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier` 를 추가하였습니다.

## 💬 ETC.

 - 작업 내용으로 인해, #60 문제는 해결하였지만 api/member 모듈을 빌드 할 시 

MemberControllerTest > 일반 로그인 테스트 FAILED                                                                               
    java.lang.IllegalStateException at DefaultCacheAwareContextLoaderDelegate.java:180                                         
        Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException at ConstructorResolver.java:798            
            Caused by: org.springframework.beans.factory.BeanCreationException at AutowiredAnnotationBeanPostProcessor.java:514
                Caused by: java.lang.IllegalArgumentException at PropertyPlaceholderHelper.java:180

MemberControllerTest > 회원가입 테스트 FAILED
    java.lang.IllegalStateException at DefaultCacheAwareContextLoaderDelegate.java:145

이라는 에러가 발생합니다. 해당 에러가 왜 발생하는지 해결을 못했습니다..ㅠㅠ

## #️⃣ 연관된 이슈
resolves: #60

