### PR TITLE
product 테스트에 통합테스트 추가, 빌드 설정 수정

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,6 +14,14 @@ jobs:
       contents: read
     # jdk 17 설정
     steps:
+      # Github Secret to .env
+      - name: Create .env file
+        run: |
+          echo OAUTH_KAKAO_CLIENTID=${{ secrets.OAUTH_KAKAO_CLIENTID }} >> .env
+          echo OAUTH_KAKAO_REDIRECT_URL=${{ secrets.OAUTH_KAKAO_REDIRECT_URL }} >> .env
+          echo OAUTH_KAKAO_CLIENT_SECRET=${{ secrets.OAUTH_KAKAO_CLIENT_SECRET }} >> .env
+          echo OAUTH_NAVER_CLIENTID=${{ secrets.OAUTH_NAVER_CLIENTID }} >> .env
+          echo OAUTH_NAVER_CLIENT_SECRET=${{ secrets.OAUTH_NAVER_CLIENT_SECRET }} >> .env
       - uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,6 +14,7 @@ jobs:
       contents: read
     # jdk 17 설정
     steps:
+      - uses: actions/checkout@v4
       # Github Secret to .env
       - name: Create .env file
         run: |
@@ -22,7 +23,6 @@ jobs:
           echo OAUTH_KAKAO_CLIENT_SECRET=${{ secrets.OAUTH_KAKAO_CLIENT_SECRET }} >> .env
           echo OAUTH_NAVER_CLIENTID=${{ secrets.OAUTH_NAVER_CLIENTID }} >> .env
           echo OAUTH_NAVER_CLIENT_SECRET=${{ secrets.OAUTH_NAVER_CLIENT_SECRET }} >> .env
-      - uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/api/store/build.gradle
+++ b/api/store/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(":core:domain")
     implementation project(":core:infra")
     implementation project(":core:security")
+    implementation testFixtures(project(':core:infra'))
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/api/store/src/test/java/com/backtothefuture/store/controller/ProductControllerTest.java
+++ b/api/store/src/test/java/com/backtothefuture/store/controller/ProductControllerTest.java
@@ -1,5 +1,6 @@
 package com.backtothefuture.store.controller;
 
+import com.backtothefuture.infra.config.BfTestConfig;
 import com.backtothefuture.store.dto.request.ProductRegisterDto;
 import com.backtothefuture.store.dto.request.ProductUpdateDto;
 import com.backtothefuture.store.dto.response.ProductResponseDto;
@@ -37,7 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(RestDocumentationExtension.class)
 @SpringBootTest
-class ProductControllerTest {
+class ProductControllerTest extends BfTestConfig {
     private MockMvc mockMvc;
 
     @MockBean

--- a/core/infra/src/main/resources/application-infra.yml
+++ b/core/infra/src/main/resources/application-infra.yml
@@ -13,7 +13,7 @@ spring:
       ddl-auto: create-drop
     defer-datasource-initialization: true
     properties:
-      dialect: org.hibernate.dialect.MySQL5InnoDBDialect
+      dialect: org.hibernate.dialect.MySQLDialect
 
   data:
     redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
       - "3306:3306" # TCP 포트 : 데이터베이스 연결 포트
     environment:
       MYSQL_ROOT_PASSWORD: 1234
+    healthcheck:
+      test: [ 'CMD', 'mysqladmin', 'ping', '-h', 'localhost', '-u', 'root', '-p$$MYSQL_ROOT_PASSWORD' ]
+      timeout: 3s
+      retries: 5
     volumes:
       - ./initdb.d:/docker-entrypoint-initdb.d
 
@@ -16,7 +20,7 @@ services:
       - "8080:8080"
     environment:
       SPRING_PROFILES_ACTIVE: dev # dev 프로파일 활성화
-      SPRING_DATASOURCE_URL: jdbc:h2:tcp://db:1521/~./test # 데이터소스 URL을 덮어쓰는 설정
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/test
       OAUTH_KAKAO_CLIENTID: ${OAUTH_KAKAO_CLIENTID}
       OAUTH_KAKAO_REDIRECT_URL: ${OAUTH_KAKAO_REDIRECT_URL}
       OAUTH_KAKAO_CLIENT_SECRET: ${OAUTH_KAKAO_CLIENT_SECRET}
@@ -25,21 +29,25 @@ services:
       SPRING_REDIS_HOST: redis
       SPRING_REDIS_PORT: 6379
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
   bagtothefuture-store:
-    image: ${DOCKER_USERNAME}/bagtothefuture-store:latest # member api 이미지
+    image: ${DOCKER_USERNAME}/bagtothefuture-store:latest # store api 이미지
     ports:
       - "8081:8081"
     environment:
       SPRING_PROFILES_ACTIVE: dev # dev 프로파일 활성화
-      SPRING_DATASOURCE_URL: jdbc:h2:tcp://db:1521/~./test # 데이터소스 URL을 덮어쓰는 설정
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/test
       SPRING_REDIS_HOST: redis
       SPRING_REDIS_PORT: 6379
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
   swagger-ui:
     image: ${DOCKER_USERNAME}/bagtothefuture-swagger:latest # swagger 이미지
@@ -50,3 +58,5 @@ services:
     image: redis:latest
     ports:
       - "6379:6379"
+    healthcheck:
+      test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]


### PR DESCRIPTION
## 📝 작업 내용
- product 테스트에 통합테스트 설정 추가
- docker compose의 db url을 mysql 설정으로 변경
- db 컨테이너가 다 뜨지 않은 상태에서 연결을 시도하고 실패하는 문제가 있어 `healthcheck` 설정 추가
- Spring <-> Mysql 연결시 Dialect 관련 에러가 발생해 Dialect 수정
  - Hibernate6 이상부터는 버전명을 명시하지 않아도 된다고 합니다.
  - 참고: https://docs.jboss.org/hibernate/orm/6.0/migration-guide/migration-guide.html#_dialects 

+) 추가
테스트 성공했습니다. 추가로 한 작업은
- Github Action에서 루트 디렉토리에 .env 파일 생성
- Github Secret에 member api application.yml 정보 셋팅

## 💬 ETC.


## #️⃣ 연관된 이슈
resolves: #63, #71 