### PR TITLE
docs: /stores 문서화 추가, api url store -> stores로 변경 #36

### DIFF
--- a/api/store/src/main/java/com/backtothefuture/store/controller/ProductController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/ProductController.java
@@ -30,7 +30,7 @@ public class ProductController {
 
     // 상품 등록 API
     // TODO: ROLE 을 STORE_OWNER, ADMIN 제한
-    @PostMapping("/store/{storeId}/products")
+    @PostMapping("/stores/{storeId}/products")
     public ResponseEntity<BfResponse<?>> registerProduct(
             @PathVariable("storeId") Long storeId,
             @Valid @RequestBody ProductRegisterDto productRegisterDto
@@ -40,7 +40,7 @@ public class ProductController {
     }
 
     // 상품 단건 조회 API
-    @GetMapping("/store/{storeId}/products/{productId}")
+    @GetMapping("/stores/{storeId}/products/{productId}")
     public ResponseEntity<BfResponse<?>> getProduct(
             @PathVariable Long storeId,
             @PathVariable Long productId
@@ -59,7 +59,7 @@ public class ProductController {
 
     // 상품 수정 API
     // TODO: ROLE 을 STORE_OWNER, ADMIN 제한
-    @PatchMapping("/store/{storeId}/products/{productId}")
+    @PatchMapping("/stores/{storeId}/products/{productId}")
     public ResponseEntity<BfResponse<?>> updateProduct(
             @PathVariable Long storeId,
             @PathVariable Long productId,
@@ -71,7 +71,7 @@ public class ProductController {
 
     // 상품 삭제 API
     // TODO: ROLE 을 STORE_OWNER, ADMIN 제한
-    @DeleteMapping("/store/{storeId}/products/{productId}")
+    @DeleteMapping("/stores/{storeId}/products/{productId}")
     public ResponseEntity<BfResponse<?>> deleteProduct(
             @PathVariable("storeId") Long storeId,
             @PathVariable("productId") Long productId

--- a/api/store/src/main/java/com/backtothefuture/store/controller/StoreController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/StoreController.java
@@ -20,11 +20,11 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/store")
+@RequestMapping("/stores")
 public class StoreController {
 	private final StoreService storeService;
 
-	@PostMapping("/register")
+	@PostMapping("")
 	public ResponseEntity<BfResponse<?>> registerStore(
 		@Valid @RequestBody StoreRegisterDto storeRegisterDto) {
 		return ResponseEntity.status(HttpStatus.CREATED)

--- a/api/store/src/main/java/com/backtothefuture/store/dto/request/StoreRegisterDto.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/request/StoreRegisterDto.java
@@ -9,7 +9,9 @@ import com.backtothefuture.store.annotation.NumericStringList;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
+@Builder
 public record StoreRegisterDto(
 	@NotBlank(message = "가게이름은 필수 항목입니다.")
 	@Size(max = 20, message = "가게이름은 최대 20자 이하로 입력해주세요.")

--- a/api/store/src/test/java/com/backtothefuture/store/controller/ProductControllerTest.java
+++ b/api/store/src/test/java/com/backtothefuture/store/controller/ProductControllerTest.java
@@ -66,7 +66,7 @@ class ProductControllerTest extends BfTestConfig {
         when(productService.getProduct(storeId, productId)).thenReturn(productResponseDto);
 
         // when & then
-        this.mockMvc.perform(get("/store/{storeId}/products/{productId}", storeId, productId)
+        this.mockMvc.perform(get("/stores/{storeId}/products/{productId}", storeId, productId)
                         .header("Authorization", "Bearer ${JWT Token}"))
                 .andExpect(status().isOk())
                 .andDo(document("get-product-by-store",
@@ -139,7 +139,7 @@ class ProductControllerTest extends BfTestConfig {
                 .build();
         when(productService.registerProduct(storeId, productRegisterDto)).thenReturn(1L);
 
-        this.mockMvc.perform(post("/store/{storeId}/products", 1)
+        this.mockMvc.perform(post("/stores/{storeId}/products", 1)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(productRegisterDto))
                         .header("Authorization", "Bearer ${JWT Token}"))
@@ -202,7 +202,7 @@ class ProductControllerTest extends BfTestConfig {
         when(productService.partialUpdateProduct(eq(storeId), eq(productId), any(ProductUpdateDto.class))).thenReturn(productResponseDto);
 
         // when & then
-        this.mockMvc.perform(patch("/store/{storeId}/products/{productId}", storeId, productId)
+        this.mockMvc.perform(patch("/stores/{storeId}/products/{productId}", storeId, productId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(productUpdateDto))
                         .header("Authorization", "Bearer ${JWT Token}"))
@@ -244,7 +244,7 @@ class ProductControllerTest extends BfTestConfig {
     @WithMockUser("USER")
     @DisplayName("상품 삭제 테스트")
     void deleteProductTest() throws Exception {
-        this.mockMvc.perform(delete("/store/{storeId}/products/{productId}", 1, 1)
+        this.mockMvc.perform(delete("/stores/{storeId}/products/{productId}", 1, 1)
                         .header("Authorization", "Bearer ${JWT Token}"))
                 .andExpect(status().isNoContent())
                 .andDo(document("delete-product",

--- a/api/store/src/test/java/com/backtothefuture/store/controller/StoreControllerTest.java
+++ b/api/store/src/test/java/com/backtothefuture/store/controller/StoreControllerTest.java
@@ -1,0 +1,103 @@
+package com.backtothefuture.store.controller;
+
+import com.backtothefuture.infra.config.BfTestConfig;
+import com.backtothefuture.store.dto.request.StoreRegisterDto;
+import com.backtothefuture.store.service.StoreService;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.epages.restdocs.apispec.SimpleType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.List;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(RestDocumentationExtension.class)
+@SpringBootTest
+class StoreControllerTest extends BfTestConfig {
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StoreService storeService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation))
+                // TODO: JWT 토큰 인증 처리 -> 실제 토큰을 발급받아 사용 or mocking(현재적용됨)
+                //.apply(springSecurity()) // Spring Security 설정 적용
+                .build();
+    }
+
+    @Test
+    @WithMockUser("USER")
+    @DisplayName("가게 등록 테스트")
+    void registerProductTest() throws Exception {
+        // given
+        Long storeId = 1L;
+        StoreRegisterDto storeRegisterDto = StoreRegisterDto.builder()
+                .name("가게 이름")
+                .description("가게 설명")
+                .location("가게 위치")
+                .contact(List.of("010", "0000", "0000"))
+                .image("이미지 url")
+                .build();
+        when(storeService.registerStore(storeRegisterDto)).thenReturn(1L);
+
+        this.mockMvc.perform(post("/stores")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(storeRegisterDto))
+                        .header("Authorization", "Bearer ${JWT Token}"))
+                .andExpect(status().isCreated())
+                .andDo(document("register-store",
+                        resource(ResourceSnippetParameters.builder()
+                                .description("가게 등록 API 입니다.")
+                                .tags("stores")
+                                .summary("가게 등록 API")
+                                // request
+                                .requestHeaders(
+                                        headerWithName("Authorization").type(SimpleType.STRING).description("JWT 인증 토큰. 'Bearer ${Jwt Token}' 형식으로 입력해 주세요.")
+                                )
+                                .requestFields(
+                                        fieldWithPath("name").type(SimpleType.STRING).description("가게 이름입니다."),
+                                        fieldWithPath("description").type(SimpleType.STRING).description("가게 상세 설명입니다."),
+                                        fieldWithPath("location").type(SimpleType.NUMBER).description("가게 위치입니다."),
+                                        fieldWithPath("contact").type(JsonFieldType.ARRAY).optional().description("연락처입니다. 문자열 배열로 입력해주세요.").optional(),
+                                        fieldWithPath("image").type(SimpleType.STRING).optional().description("썸네일 이미지 입니다.")
+                                )
+                                .requestSchema(Schema.schema("[request] store-register"))
+                                // response
+                                .responseFields(
+                                        fieldWithPath("code").type(SimpleType.NUMBER).description("HttpStatusCode 입니다."),
+                                        fieldWithPath("message").type(SimpleType.STRING).description("응답 메시지 입니다."),
+                                        fieldWithPath("data.store_id").type(SimpleType.NUMBER).description("생성된 가게 ID 입니다.")
+                                )
+                                .responseSchema(Schema.schema("[response] store-register")).build()
+                        )));
+    }
+}

--- a/docs/openapi/store-openapi.yaml
+++ b/docs/openapi/store-openapi.yaml
@@ -28,7 +28,43 @@ paths:
                     :10000,\"stockQuantity\":10,\"thumbnail\":\"thumbnail1\"},{\"\
                     id\":2,\"name\":\"상품2\",\"description\":\"상품2 설명\",\"price\":20000,\"\
                     stockQuantity\":20,\"thumbnail\":\"thumbnail2\"}]}}"
-  /store/{storeId}/products:
+  /stores:
+    post:
+      tags:
+      - stores
+      summary: 가게 등록 API
+      description: 가게 등록 API 입니다.
+      operationId: register-store
+      parameters:
+      - name: Authorization
+        in: header
+        description: "JWT 인증 토큰. 'Bearer ${Jwt Token}' 형식으로 입력해 주세요."
+        required: true
+        schema:
+          type: string
+        example: "Bearer ${JWT Token}"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/[request] store-register"
+            examples:
+              register-store:
+                value: "{\"name\":\"가게 이름\",\"description\":\"가게 설명\",\"location\"\
+                  :\"가게 위치\",\"contact\":[\"010\",\"0000\",\"0000\"],\"image\":\"이\
+                  미지 url\"}"
+      responses:
+        "201":
+          description: "201"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/[response] store-register"
+              examples:
+                register-store:
+                  value: "{\"code\":201,\"message\":\"정상적으로 생성되었습니다.\",\"data\":{\"\
+                    store_id\":1}}"
+  /stores/{storeId}/products:
     post:
       tags:
       - products
@@ -69,7 +105,7 @@ paths:
                 register-product:
                   value: "{\"code\":201,\"message\":\"정상적으로 생성되었습니다.\",\"data\":{\"\
                     product_id\":1}}"
-  /store/{storeId}/products/{productId}:
+  /stores/{storeId}/products/{productId}:
     get:
       tags:
       - products
@@ -309,6 +345,37 @@ components:
         message:
           type: string
           description: 응답 메시지 입니다.
+    '[request] store-register':
+      title: "[request] store-register"
+      required:
+      - description
+      - location
+      - name
+      type: object
+      properties:
+        image:
+          type: string
+          description: 썸네일 이미지 입니다.
+          nullable: true
+        contact:
+          type: array
+          description: 연락처입니다. 문자열 배열로 입력해주세요.
+          nullable: true
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
+        name:
+          type: string
+          description: 가게 이름입니다.
+        description:
+          type: string
+          description: 가게 상세 설명입니다.
+        location:
+          type: number
+          description: 가게 위치입니다.
     '[request] product-register':
       title: "[request] product-register"
       required:
@@ -375,6 +442,27 @@ components:
                 id:
                   type: number
                   description: 상품 ID
+        message:
+          type: string
+          description: 응답 메시지 입니다.
+    '[response] store-register':
+      title: "[response] store-register"
+      required:
+      - code
+      - message
+      type: object
+      properties:
+        code:
+          type: number
+          description: HttpStatusCode 입니다.
+        data:
+          required:
+          - store_id
+          type: object
+          properties:
+            store_id:
+              type: number
+              description: 생성된 가게 ID 입니다.
         message:
           type: string
           description: 응답 메시지 입니다.


### PR DESCRIPTION
## 📝 작업 내용
 - store api 문서화 추가
 - url을 `/store` -> `/stores`로 변경
<img width="1281" alt="image" src="https://github.com/backtothefuture-team/backtothefuture-backend/assets/67352902/0d2f9f86-8ef0-4369-adbe-db19484d548d">


## 💬 ETC.

## #️⃣ 연관된 이슈
resolves: #36