### PR TITLE
Fix: ddl-atuo : create-drop 시 발생하는 테이블 생성 에러 수정

### DIFF
--- a/api/event/build.gradle
+++ b/api/event/build.gradle
@@ -33,20 +33,3 @@ openapi3 {
     outputFileNamePrefix = 'event-openapi'
     format = 'yaml'
 }
-
-task makeOpenapi {
-    dependsOn 'openapi3'
-    doFirst {
-        def swaggerUIFile = file("${openapi3.outputDirectory}/event-openapi.yaml")
-
-        def securitySchemesContent =  "  securitySchemes:\n" +  \
-                                      "    bearerAuth:\n" +  \
-                                      "      type: http\n" +  \
-                                      "      scheme: bearer\n" +  \
-                                      "      bearerFormat: JWT\n" + \
-                                      "security:\n" +
-                "  - bearerAuth: []"
-
-        swaggerUIFile.append securitySchemesContent
-    }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ subprojects {
 task copyOpenApiSpecsToDocsDir(type: Copy) {
 	dependsOn ':api:member:openapi3'
 	dependsOn ':api:store:makeOpenapi'
-	dependsOn ':api:event:makeOpenapi'
+	dependsOn ':api:event:openapi3'
 
 	// member
 	from "${project(':api:member').buildDir}/api-spec/member-openapi.yaml"

--- a/core/domain/src/main/java/com/backtothefuture/domain/member/Member.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/member/Member.java
@@ -45,12 +45,15 @@ public class Member extends MutableBaseEntity {
 	private String phoneNumber;		// 연락처
 
 	@Enumerated(EnumType.STRING)
+	@Column(columnDefinition = "VARCHAR(255)")
 	private StatusType status = StatusType.PENDING; // 상태
 
 	@Enumerated(EnumType.STRING)
+	@Column(columnDefinition = "VARCHAR(255)")
 	private ProviderType provider;	// 계정정보 공급 서비스
 
 	@Setter
 	@Enumerated(EnumType.STRING)
+	@Column(columnDefinition = "VARCHAR(255)")
 	private RolesType roles = RolesType.ROLE_USER;		// 권한
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/product/Product.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/product/Product.java
@@ -32,6 +32,7 @@ public class Product extends MutableBaseEntity {
     private String name;            // 상품 이름
 
     @Lob
+    @Column(columnDefinition = "TEXT")
     private String description;     // 상품 설명
 
     private int price;              // 상품 가격

--- a/core/domain/src/main/java/com/backtothefuture/domain/store/Store.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/store/Store.java
@@ -31,6 +31,7 @@ public class Store extends MutableBaseEntity {
 	private String name; 		// 가게 이름
 
 	@Lob
+	@Column(columnDefinition = "TEXT")
 	private String description; // 가게 설명
 
 	private String location;	// 가게 위치

--- a/core/infra/src/main/resources/application-infra.yml
+++ b/core/infra/src/main/resources/application-infra.yml
@@ -15,11 +15,17 @@ spring:
     properties:
       dialect: org.hibernate.dialect.MySQLDialect
 
+
   data:
     redis:
       # docker container 시작 시 환경 변수를 전달 받도록 한다.
       host: ${SPRING_REDIS_HOST:localhost} # 기본값을 localhost로 설정
       port: ${SPRING_REDIS_PORT:6379} # 기본값을 6379로 설정
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:core/infra/src/main/resources/schema.sql
+
 logging:
   level:
     org.hibernate:

--- a/core/infra/src/main/resources/application-infra.yml
+++ b/core/infra/src/main/resources/application-infra.yml
@@ -23,8 +23,9 @@ spring:
       port: ${SPRING_REDIS_PORT:6379} # 기본값을 6379로 설정
   sql:
     init:
-      mode: always
-      schema-locations: classpath:core/infra/src/main/resources/schema.sql
+      # main 함수 실행 시, schema.sql 작동하도록 멀티 모듈 환경에서 classpath: 설정하기
+      #mode: always
+      #schema-locations: classpath:schema.sql
 
 logging:
   level:

--- a/core/infra/src/main/resources/application-infra.yml
+++ b/core/infra/src/main/resources/application-infra.yml
@@ -10,7 +10,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
     defer-datasource-initialization: true
     properties:
       dialect: org.hibernate.dialect.MySQLDialect

--- a/core/infra/src/main/resources/schema.sql
+++ b/core/infra/src/main/resources/schema.sql
@@ -1,0 +1,51 @@
+DROP DATABASE IF EXISTS test;
+CREATE DATABASE IF NOT EXISTS test;
+USE test;
+
+CREATE TABLE member (
+                        member_id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                        auth_id varchar(255),
+                        email varchar(255) UNIQUE,
+                        name varchar(255),
+                        password varchar(255),
+                        phone_number varchar(255) UNIQUE,
+                        status varchar(255),
+                        provider varchar(255),
+                        roles varchar(255),
+                        updated_at datetime(6),
+                        updated_by varchar(255),
+                        created_at datetime(6),
+                        created_by varchar(255)
+);
+
+
+CREATE TABLE store (
+                       store_id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                       name varchar(255),
+                       description TEXT,
+                       location varchar(255),
+                       contact varchar(255),
+                       image varchar(255),
+                       member_id bigint NOT NULL,
+                       updated_at datetime(6),
+                       updated_by varchar(255),
+                       created_at datetime(6),
+                       created_by varchar(255),
+                       FOREIGN KEY(member_id) REFERENCES member(member_id)
+);
+
+CREATE TABLE product (
+                         product_id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                         name varchar(255),
+                         description TEXT,
+                         price int,
+                         stock_quantity int,
+                         thumbnail varchar(255),
+                         store_id bigint NOT NULL,
+                         updated_at datetime(6),
+                         updated_by varchar(255),
+                         created_at datetime(6),
+                         created_by varchar(255),
+                         FOREIGN KEY(store_id) REFERENCES store(store_id)
+);
+

--- a/docs/openapi/event-openapi.yaml
+++ b/docs/openapi/event-openapi.yaml
@@ -22,7 +22,7 @@ paths:
             examples:
               verify-certificate-number:
                 value: "{\"phoneNumber\":[\"010\",\"1234\",\"5678\"],\"certificationNumber\"\
-                  :\"185479\"}"
+                  :\"158745\"}"
       responses:
         "200":
           description: "200"
@@ -34,7 +34,7 @@ paths:
                 verify-certificate-number:
                   value: "{\"code\":200,\"message\":\"정상 처리되었습니다.\"}"
   /certificate/message/{phoneNumber}:
-    get:
+    post:
       tags:
       - certificate
       summary: 인증 번호 발급 API
@@ -57,7 +57,7 @@ paths:
               examples:
                 get-certificate-number:
                   value: "{\"code\":201,\"message\":\"정상적으로 생성되었습니다.\",\"data\":{\"\
-                    certification_number\":\"731014\"}}"
+                    certification_number\":\"402195\"}}"
 components:
   schemas:
     '[response] verify-certificate-number':
@@ -113,10 +113,3 @@ components:
         certificationNumber:
           type: string
           description: 인증번호
-  securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
-security:
-  - bearerAuth: []

--- a/initdb.d/init.sql
+++ b/initdb.d/init.sql
@@ -1,2 +1,51 @@
+DROP DATABASE IF EXISTS test;
 CREATE DATABASE IF NOT EXISTS test;
 USE test;
+
+CREATE TABLE member (
+    member_id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    auth_id varchar(255),
+    email varchar(255) UNIQUE,
+    name varchar(255),
+    password varchar(255),
+    phone_number varchar(255) UNIQUE,
+    status varchar(255),
+    provider varchar(255),
+    roles varchar(255),
+    updated_at datetime(6),
+    updated_by varchar(255),
+    created_at datetime(6),
+    created_by varchar(255)
+);
+
+
+CREATE TABLE store (
+    store_id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name varchar(255),
+    description TEXT,
+    location varchar(255),
+    contact varchar(255),
+    image varchar(255),
+    member_id bigint NOT NULL,
+    updated_at datetime(6),
+    updated_by varchar(255),
+    created_at datetime(6),
+    created_by varchar(255),
+    FOREIGN KEY(member_id) REFERENCES member(member_id)
+);
+
+CREATE TABLE product (
+    product_id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name varchar(255),
+    description TEXT,
+    price int,
+    stock_quantity int,
+    thumbnail varchar(255),
+    store_id bigint NOT NULL,
+    updated_at datetime(6),
+    updated_by varchar(255),
+    created_at datetime(6),
+    created_by varchar(255),
+    FOREIGN KEY(store_id) REFERENCES store(store_id)
+);
+


### PR DESCRIPTION
## 📝 작업 내용
 - ddl-auto : create-drop에서 validate로 수정했습니다.
 - 이에 따라 init.sql 작성했습니다.
 - api 문서화 수정했습니다.

## 💬 ETC.
- https://mycup.tistory.com/382
- https://ttl-blog.tistory.com/117
    -   @LOB 사용 시, MySQL에서 문자열은 TEXT 데이터 타입을 사용해야 함.

## #️⃣ 연관된 이슈
resolves: #82 