### PR TITLE
fix: 환경 변수 주입 안 되는 에러로 인해 임시 문자열 처리

### DIFF
--- a/api/event/src/main/resources/application.yml
+++ b/api/event/src/main/resources/application.yml
@@ -11,9 +11,9 @@ spring:
 
   certification:
     coolsms:
-      fromPhoneNumber: ${COOLSMS_FROM_PHONE_NUMBER}
-      api: ${COOLSMS_API_KEY}
-      secret: ${COOLSMS_API_SECRET_KEY}
+      fromPhoneNumber: 01000000000
+      api: test
+      secret: test
 
 server:
   port: 8084


### PR DESCRIPTION
## 📝 작업 내용
 - @Value를 사용한 환경 변수 주입 안 되는 에러로 인해 임시 문자열 처리했습니다.

## 💬 ETC.


## #️⃣ 연관된 이슈
resolves: #84 