### PR TITLE
feat: 인증 메일 api 추가 및 문서화, 로컬환경 설정 버그 수정

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -26,6 +26,8 @@ jobs:
           echo COOLSMS_FROM_PHONE_NUMBER=${{ secrets.COOLSMS_FROM_PHONE_NUMBER }} >> .env
           echo COOLSMS_API_KEY=${{ secrets.COOLSMS_API_KEY }} >> .env
           echo COOLSMS_API_SECRET_KEY=${{ secrets.COOLSMS_API_SECRET_KEY }} >> .env
+          echo MAIL_USERNAME=${{ secrets.MAIL_USERNAME }} >> .env
+          echo MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }} >> .env
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/api/event/build.gradle
+++ b/api/event/build.gradle
@@ -26,6 +26,9 @@ dependencies {
 
     // mail
     implementation 'org.springframework.boot:spring-boot-starter-mail:3.2.4'
+
+    // timeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 openapi3 {

--- a/api/event/build.gradle
+++ b/api/event/build.gradle
@@ -21,8 +21,11 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-security"
 
-    //coolsms
+    // coolsms
     implementation 'net.nurigo:sdk:4.3.0'
+
+    // mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail:3.2.4'
 }
 
 openapi3 {

--- a/api/event/src/main/java/com/backtothefuture/event/EventApplication.java
+++ b/api/event/src/main/java/com/backtothefuture/event/EventApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @ComponentScan(basePackages = {"com.backtothefuture"})
 public class EventApplication {

--- a/api/event/src/main/java/com/backtothefuture/event/controller/CertificateController.java
+++ b/api/event/src/main/java/com/backtothefuture/event/controller/CertificateController.java
@@ -54,6 +54,7 @@ public class CertificateController {
                 .body(new BfResponse<>(SUCCESS, Map.of("mail_expiration_seconds", mailExp)));
     }
 
+    // TODO: html 버튼, form 전송으로 변경할것
     @GetMapping("/email")
     public ModelAndView verifyCertificateMail(
             @RequestParam String email,
@@ -63,5 +64,11 @@ public class CertificateController {
         // 인증 성공 시 성공 페이지를 반환
         ModelAndView successModelAndView = new ModelAndView("mail/verify-success");
         return successModelAndView;
+    }
+
+    @GetMapping("/email/{email}/status")
+    public ResponseEntity<BfResponse<?>> checkCertificateEmailStatus(@PathVariable String email) {
+        return ResponseEntity.ok()
+                .body(new BfResponse<>(SUCCESS, Map.of("is_certificated", certificationService.getCertificateEmailStatus(email))));
     }
 }

--- a/api/event/src/main/java/com/backtothefuture/event/controller/CertificateController.java
+++ b/api/event/src/main/java/com/backtothefuture/event/controller/CertificateController.java
@@ -1,17 +1,25 @@
 package com.backtothefuture.event.controller;
 
 import com.backtothefuture.domain.response.BfResponse;
+import com.backtothefuture.event.dto.request.MailCertificateRequestDto;
 import com.backtothefuture.event.dto.request.VerifyCertificateRequestDto;
 import com.backtothefuture.event.service.CertificateService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
 import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.CREATE;
+import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.SUCCESS;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,7 +28,7 @@ public class CertificateController {
 
     private final CertificateService certificationService;
 
-    @PostMapping ("/message/{phoneNumber}") // 인증 번호 발급
+    @PostMapping("/message/{phoneNumber}") // 인증 번호 발급
     public ResponseEntity<BfResponse<?>> getCertificateNumber(@PathVariable String phoneNumber) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new BfResponse<>(CREATE, Map.of("certification_number",
@@ -33,5 +41,15 @@ public class CertificateController {
             @Valid @RequestBody VerifyCertificateRequestDto request) {
         certificationService.verifyCertificateNumber(request);
         return ResponseEntity.ok(new BfResponse<>(null));
+    }
+
+    @PostMapping("/email")
+    public ResponseEntity<BfResponse<?>> sendCertificateMail(
+            @Valid @RequestBody MailCertificateRequestDto mailCertificateRequestDto
+    ) {
+        int mailExp = certificationService.sendEmailCertificateNumber(mailCertificateRequestDto);
+
+        return ResponseEntity.ok()
+                .body(new BfResponse<>(SUCCESS, Map.of("mail_expiration_seconds", mailExp)));
     }
 }

--- a/api/event/src/main/java/com/backtothefuture/event/controller/CertificateController.java
+++ b/api/event/src/main/java/com/backtothefuture/event/controller/CertificateController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.ModelAndView;
 
 import java.util.Map;
 
@@ -51,5 +52,16 @@ public class CertificateController {
 
         return ResponseEntity.ok()
                 .body(new BfResponse<>(SUCCESS, Map.of("mail_expiration_seconds", mailExp)));
+    }
+
+    @GetMapping("/email")
+    public ModelAndView verifyCertificateMail(
+            @RequestParam String email,
+            @RequestParam String certificationNumber
+    ) {
+        certificationService.verifyCertificateEmailNumber(email, certificationNumber);
+        // 인증 성공 시 성공 페이지를 반환
+        ModelAndView successModelAndView = new ModelAndView("mail/verify-success");
+        return successModelAndView;
     }
 }

--- a/api/event/src/main/java/com/backtothefuture/event/dto/request/MailCertificateRequestDto.java
+++ b/api/event/src/main/java/com/backtothefuture/event/dto/request/MailCertificateRequestDto.java
@@ -1,0 +1,13 @@
+package com.backtothefuture.event.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+
+public record MailCertificateRequestDto(
+
+        @NotEmpty(message = "이메일 입력은 필수 입니다.")
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")
+        String email
+
+) {
+}

--- a/api/event/src/main/java/com/backtothefuture/event/exception/CertificateException.java
+++ b/api/event/src/main/java/com/backtothefuture/event/exception/CertificateException.java
@@ -4,11 +4,11 @@ import com.backtothefuture.domain.common.enums.CertificateErrorCode;
 import lombok.Getter;
 
 @Getter
-public class MessageException extends RuntimeException{
+public class CertificateException extends RuntimeException{
 
     private final CertificateErrorCode errorCode;
 
-    public MessageException(CertificateErrorCode errorCode) {
+    public CertificateException(CertificateErrorCode errorCode) {
         super(errorCode.getErrorMessage());
         this.errorCode = errorCode;
     }

--- a/api/event/src/main/java/com/backtothefuture/event/exception/GlobalExceptionHandler.java
+++ b/api/event/src/main/java/com/backtothefuture/event/exception/GlobalExceptionHandler.java
@@ -5,10 +5,12 @@ import com.backtothefuture.domain.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import static com.backtothefuture.domain.common.enums.GlobalErrorCode.INTERNAL_SERVER_ERROR;
+import static com.backtothefuture.domain.common.enums.GlobalErrorCode.VALIDATION_FAILED;
 
 @Slf4j
 @RestControllerAdvice
@@ -21,10 +23,23 @@ public class GlobalExceptionHandler {
                 .body(INTERNAL_SERVER_ERROR.getErrorResponse());
     }
 
-    @ExceptionHandler(MessageException.class)
-    protected ResponseEntity<ErrorResponse> handleCertificationException(MessageException ex) {
+    @ExceptionHandler(CertificateException.class)
+    protected ResponseEntity<ErrorResponse> handleCertificationException(CertificateException ex) {
         log.error(">>>>> Internal Server Error : {}", ex);
         BaseErrorCode errorCode = ex.getErrorCode();
         return ResponseEntity.status(errorCode.getStatus()).body(errorCode.getErrorResponse());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        log.error(">>>>> MethodArgumentNotValidException : {}", ex);
+        ErrorResponse errorResponse = VALIDATION_FAILED.getErrorResponse();
+        ex.getBindingResult().getFieldErrors().forEach(fieldError -> {
+            String field = fieldError.getField();
+            String message = fieldError.getDefaultMessage();
+            errorResponse.addValidation(field, message);
+        });
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 }

--- a/api/event/src/main/java/com/backtothefuture/event/exception/GlobalExceptionHandler.java
+++ b/api/event/src/main/java/com/backtothefuture/event/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.ModelAndView;
 
 import static com.backtothefuture.domain.common.enums.GlobalErrorCode.INTERNAL_SERVER_ERROR;
 import static com.backtothefuture.domain.common.enums.GlobalErrorCode.VALIDATION_FAILED;
@@ -41,5 +42,14 @@ public class GlobalExceptionHandler {
         });
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    /**
+     * 메일 인증 실패 html error 페이지 반환
+     */
+    @ExceptionHandler(VerifyMailFailException.class)
+    public ModelAndView handleCertificateException(VerifyMailFailException e) {
+        ModelAndView modelAndView = new ModelAndView("mail/verify-fail");
+        return modelAndView;
     }
 }

--- a/api/event/src/main/java/com/backtothefuture/event/exception/VerifyMailFailException.java
+++ b/api/event/src/main/java/com/backtothefuture/event/exception/VerifyMailFailException.java
@@ -1,0 +1,14 @@
+package com.backtothefuture.event.exception;
+
+import com.backtothefuture.domain.common.enums.CertificateErrorCode;
+import lombok.Getter;
+
+@Getter
+public class VerifyMailFailException extends RuntimeException{
+    private final CertificateErrorCode errorCode;
+
+    public VerifyMailFailException(CertificateErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/api/event/src/main/java/com/backtothefuture/event/service/CertificateService.java
+++ b/api/event/src/main/java/com/backtothefuture/event/service/CertificateService.java
@@ -102,6 +102,10 @@ public class CertificateService {
         redisRepository.setMailCertificationFlag(email);
     }
 
+    public boolean getCertificateEmailStatus(String email) {
+        return redisRepository.getMailCertificationFlag(email);
+    }
+
     public String getServerUrl() {
         return baseUrl + "/certificate/email";
     }

--- a/api/event/src/main/java/com/backtothefuture/event/service/CertificateService.java
+++ b/api/event/src/main/java/com/backtothefuture/event/service/CertificateService.java
@@ -73,9 +73,7 @@ public class CertificateService {
                 getServerUrl(), randomNumber, email);
 
         // 메일 내용 설정
-        HashMap<String, String> content = new HashMap<>();
-        content.put("subject", "메일 제목");
-        content.put("text", "메일 내용, 인증 url = " + certificateUrl);
+        HashMap<String, String> content = getCertificationMailContent(certificateUrl);
 
         // 메일 전송
         try {
@@ -104,6 +102,13 @@ public class CertificateService {
 
     public boolean getCertificateEmailStatus(String email) {
         return redisRepository.getMailCertificationFlag(email);
+    }
+
+    public HashMap<String, String> getCertificationMailContent(String certificateUrl) {
+        return new HashMap<>(){{
+            put("subject", "메일 제목");
+            put("text", "메일 내용, 인증 url = " + certificateUrl);
+        }};
     }
 
     public String getServerUrl() {

--- a/api/event/src/main/java/com/backtothefuture/event/service/CertificateService.java
+++ b/api/event/src/main/java/com/backtothefuture/event/service/CertificateService.java
@@ -3,11 +3,18 @@ package com.backtothefuture.event.service;
 import com.backtothefuture.domain.common.enums.CertificateErrorCode;
 import com.backtothefuture.domain.common.repository.RedisRepository;
 import com.backtothefuture.domain.common.util.RandomNumUtil;
+import com.backtothefuture.event.dto.request.MailCertificateRequestDto;
 import com.backtothefuture.event.dto.request.VerifyCertificateRequestDto;
-import com.backtothefuture.event.exception.MessageException;
+import com.backtothefuture.event.exception.CertificateException;
+import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CertificateService {
@@ -15,6 +22,11 @@ public class CertificateService {
     private final CoolsmsService coolsmsService;
 
     private final RedisRepository redisRepository;
+
+    private final MailService mailService;
+
+    @Value("${spring.certification.mail.baseurl}")
+    private String baseUrl;
 
     public String getCertificateNumber(String phoneNumber) {
         String parsePhoneNum = parsePhoneNumber(phoneNumber); // 전화번호 parse
@@ -28,7 +40,7 @@ public class CertificateService {
     public void verifyCertificateNumber(VerifyCertificateRequestDto request) {
         // 유효 번호 검증
         if (!validateCertificationNumber(request.getPhoneNumber(), request.certificationNumber()))
-            throw new MessageException(CertificateErrorCode.INVALID_CERTIFCATE_NUMBER);
+            throw new CertificateException(CertificateErrorCode.INVALID_CERTIFCATE_NUMBER);
 
         redisRepository.deleteCertificationNumber(request.getPhoneNumber());
     }
@@ -37,7 +49,7 @@ public class CertificateService {
         String parseNum = phoneNumber.replace("-", "");
 
         if (!parseNum.matches("[0-9]+")) {
-            throw new MessageException(CertificateErrorCode.INVALID_PHONE_NUMBER);
+            throw new CertificateException(CertificateErrorCode.INVALID_PHONE_NUMBER);
         }
 
         return parseNum; // 010-1234-1234 >> 01012341234 형태로 parse
@@ -47,5 +59,34 @@ public class CertificateService {
         // 해당 key의 value 값이 존재 하는지 + 인증 번호가 일치 하는지
         return (redisRepository.hasKey(phoneNumber) && redisRepository.getCertificationNumber(
                 phoneNumber).equals(certificationNumber));
+    }
+
+    public int sendEmailCertificateNumber(MailCertificateRequestDto mailCertificateRequestDto) {
+        String email = mailCertificateRequestDto.email();
+
+        // 랜덤 번호 발급
+        String randomNumber = RandomNumUtil.createRandomNum(6); // 6자리 임의의 숫자 생성
+
+        // 인증 url 설정
+        String certificateUrl = String.format("%s?certificationNumber=%s&email=%s",
+                getServerUrl(), randomNumber, email);
+
+        // 메일 내용 설정
+        HashMap<String, String> content = new HashMap<>();
+        content.put("subject", "메일 제목");
+        content.put("text", "메일 내용, 인증 url = " + certificateUrl);
+
+        // 메일 전송
+        try {
+            mailService.sendMail(email, content);
+        } catch (MessagingException e) {
+            log.error("fail to send mail", e);
+            throw new CertificateException(CertificateErrorCode.MAIL_SEND_ERROR);
+        }
+
+        // 임시 발급 번호 redis에 저장
+        redisRepository.saveCertificationEmailNumber(email, randomNumber);
+
+        return redisRepository.getMailExp();
     }
 }

--- a/api/event/src/main/java/com/backtothefuture/event/service/CoolsmsService.java
+++ b/api/event/src/main/java/com/backtothefuture/event/service/CoolsmsService.java
@@ -2,7 +2,7 @@ package com.backtothefuture.event.service;
 
 import com.backtothefuture.domain.common.enums.CertificateErrorCode;
 import com.backtothefuture.domain.common.repository.RedisRepository;
-import com.backtothefuture.event.exception.MessageException;
+import com.backtothefuture.event.exception.CertificateException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.nurigo.sdk.message.exception.NurigoEmptyResponseException;
@@ -40,7 +40,7 @@ public class CoolsmsService {
             MultipleDetailMessageSentResponse response = defaultMessageService.send(message); // 메시지 전송
         } catch (NurigoEmptyResponseException | NurigoMessageNotReceivedException |
                  NurigoUnknownException ex) {
-            throw new MessageException(CertificateErrorCode.MESSAGE_SEND_ERROR);
+            throw new CertificateException(CertificateErrorCode.MESSAGE_SEND_ERROR);
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }

--- a/api/event/src/main/java/com/backtothefuture/event/service/MailService.java
+++ b/api/event/src/main/java/com/backtothefuture/event/service/MailService.java
@@ -16,6 +16,7 @@ public class MailService {
 
     private final JavaMailSender mailSender;
 
+    @Async
     public void sendMail(String mail, HashMap<String, String> content) throws MessagingException {
         // set mail
         MimeMessage mimeMessage = mailSender.createMimeMessage();

--- a/api/event/src/main/java/com/backtothefuture/event/service/MailService.java
+++ b/api/event/src/main/java/com/backtothefuture/event/service/MailService.java
@@ -1,0 +1,31 @@
+package com.backtothefuture.event.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendMail(String mail, HashMap<String, String> content) throws MessagingException {
+        // set mail
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage);
+
+        helper.setTo(mail);
+        helper.setSubject(content.get("subject"));
+        helper.setText(content.get("text"));
+
+        // send mail
+        mailSender.send(mimeMessage);
+    }
+}

--- a/api/event/src/main/resources/application.yml
+++ b/api/event/src/main/resources/application.yml
@@ -14,6 +14,19 @@ spring:
       fromPhoneNumber: ${COOLSMS_FROM_PHONE_NUMBER}
       api: ${COOLSMS_API_KEY}
       secret: ${COOLSMS_API_SECRET_KEY}
+    mail:
+      baseurl: "http://localhost:8084/v1"
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    properties:
+      mail:
+        debug: true
+        smtp.auth: true
+        smtp.timeout: 50000 # SMTP 서버 연결 시도 timeout
+        smtp.starttls.enable: true
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
 
 server:
   port: 8084

--- a/api/event/src/main/resources/templates/mail/verify-fail.html
+++ b/api/event/src/main/resources/templates/mail/verify-fail.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>인증 결과</title>
+</head>
+<h1>인증에 실패하였습니다. 인증을 다시 시도해 주세요.</h1>
+</html>

--- a/api/event/src/main/resources/templates/mail/verify-success.html
+++ b/api/event/src/main/resources/templates/mail/verify-success.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>인증 결과</title>
+    <meta charset="utf-8">
+</head>
+    <h1>성공적으로 인증되었습니다. 앱 화면으로 돌아가 주세요.</h1>
+</html>

--- a/api/event/src/test/java/com/backtothefuture/event/EventApplicationTests.java
+++ b/api/event/src/test/java/com/backtothefuture/event/EventApplicationTests.java
@@ -1,11 +1,13 @@
 package com.backtothefuture.event;
 
 import com.backtothefuture.domain.common.util.RandomNumUtil;
+import com.backtothefuture.event.dto.request.MailCertificateRequestDto;
 import com.backtothefuture.event.dto.request.VerifyCertificateRequestDto;
 import com.backtothefuture.event.service.CertificateService;
 import com.backtothefuture.infra.config.BfTestConfig;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
+import com.epages.restdocs.apispec.SimpleType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,7 +20,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -29,11 +30,14 @@ import java.util.List;
 import java.util.Map;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 
 
 @ExtendWith(RestDocumentationExtension.class)
@@ -58,6 +62,7 @@ class EventApplicationTests extends BfTestConfig {
                 .apply(documentationConfiguration(restDocumentation))
                 .build();
     }
+
     @Test
     @DisplayName("인증 번호 발급 테스트")
     void getCertificateTest() throws Exception {
@@ -94,7 +99,7 @@ class EventApplicationTests extends BfTestConfig {
         verifyMap.put("phoneNumber", List.of("010", "1234", "5678"));
         verifyMap.put("certificationNumber", randomNum);
 
-        VerifyCertificateRequestDto request = new VerifyCertificateRequestDto( List.of("010", "1234", "5678"), randomNum);
+        VerifyCertificateRequestDto request = new VerifyCertificateRequestDto(List.of("010", "1234", "5678"), randomNum);
 
         //when,then
         this.mockMvc.perform(post("/certificate/message")
@@ -119,4 +124,71 @@ class EventApplicationTests extends BfTestConfig {
                         )));
     }
 
+    @Test
+    @DisplayName("인증 메일 전송 테스트")
+    void sendCertificateMailTest() throws Exception {
+        MailCertificateRequestDto requestDto = new MailCertificateRequestDto("test@example.com");
+        when(certificateService.sendEmailCertificateNumber(any(MailCertificateRequestDto.class))).thenReturn(600);
+
+        this.mockMvc.perform(post("/email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andDo(document("send-certificate-email",
+                        resource(ResourceSnippetParameters.builder()
+                                .description("인증 메일 전송 API 입니다.")
+                                .tag("certificate")
+                                .summary("인증 메일 전송 API")
+                                .responseFields(
+                                        fieldWithPath("email").type(SimpleType.STRING).description("이메일")
+                                )
+                                .responseSchema(Schema.schema("[request] send-certificate-email"))
+                                .responseFields(
+                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                        fieldWithPath("data.mail_expiration_seconds").type(SimpleType.INTEGER).description("인증 만료 시간(초)")
+                                )
+                                .responseSchema(Schema.schema("[response] send-certificate-email")).build())));
+    }
+
+    @Test
+    @DisplayName("인증 메일 검증 테스트")
+    void verifyCertificateMailTest() throws Exception {
+        this.mockMvc.perform(get("/email")
+                        .param("email", "test@example.com")
+                        .param("certificationNumber", "123456"))
+                .andExpect(status().isOk())
+                .andDo(document("verify-certificate-email",
+                        resource(ResourceSnippetParameters.builder()
+                                .description("인증 메일 검증 API입니다. 메일 수신자가 클릭하는 링크가 됩니다.")
+                                .tag("certificate")
+                                .summary("인증 메일 검증")
+                                .responseFields(
+                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
+                                )
+                                .responseSchema(Schema.schema("[response] verify-certificate-email"))
+                                .build())));
+    }
+
+    @Test
+    @DisplayName("이메일 인증 상태 확인 테스트")
+    void checkCertificateEmailStatusTest() throws Exception {
+        when(certificateService.getCertificateEmailStatus("test@example.com")).thenReturn(true);
+
+        this.mockMvc.perform(get("/email/{email}/status", "test@example.com"))
+                .andExpect(status().isOk())
+                .andDo(document("check-certificate-email-status",
+                        resource(ResourceSnippetParameters.builder()
+                                .description("이메일 인증 상태 확인 API입니다.")
+                                .tag("certificate")
+                                .summary("이메일 인증 상태 확인")
+                                .responseFields(
+                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                        fieldWithPath("data.is_certificated").type(JsonFieldType.BOOLEAN).description("인증 여부. true: 인증 / false: 미인증")
+                                )
+                                .responseSchema(Schema.schema("[response] check-certificate-email-status"))
+                                .build())));
+    }
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/enums/CertificateErrorCode.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/enums/CertificateErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum CertificateErrorCode implements BaseErrorCode{
     MESSAGE_SEND_ERROR(500,"메세지 전송 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    MAIL_SEND_ERROR(500,"메일 전송 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INVALID_PHONE_NUMBER(400,"유효하지 않는 번호 형태입니다.",HttpStatus.BAD_REQUEST),
     INVALID_CERTIFCATE_NUMBER(404,"유효하지 않는 인증 번호입니다.",HttpStatus.NOT_FOUND);
 

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/repository/RedisRepository.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/repository/RedisRepository.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Repository;
+import java.util.concurrent.TimeUnit;
 
 import lombok.RequiredArgsConstructor;
 
@@ -56,6 +57,50 @@ public class RedisRepository {
 	 */
 	public int getMailExp() {
 		return mailExp;
+	}
+
+	/**
+	 * 비트 값을 설정하고 만료 시간을 지정
+	 *
+	 * @param key    Redis 키
+	 * @param offset 비트 위치
+	 * @param value  설정할 비트 값
+	 * @param ttl    만료 시간 (초 단위)
+	 */
+	protected void setBitWithExpiration(String key, long offset, boolean value, int ttl) {
+		redisTemplate.opsForValue().setBit(key, offset, value);
+		redisTemplate.expire(key, ttl, TimeUnit.SECONDS);
+	}
+
+	/**
+	 * 비트 값 조회
+	 *
+	 * @param key    Redis 키
+	 * @param offset 비트 위치
+	 * @return 비트 값 (boolean)
+	 */
+	protected boolean getBit(String key, long offset) {
+		Boolean value = redisTemplate.opsForValue().getBit(key, offset);
+		return value != null && value;
+	}
+
+	public void setMailCertificationFlag(String email) {
+		String mailCertificatedKey = getMailCertificationKey(email);
+		setBitWithExpiration(mailCertificatedKey, 0, true, mailExp);
+	}
+
+	public Boolean getMailCertificationFlag(String email) {
+		String mailCertificatedKey = getMailCertificationKey(email);
+		return getBit(mailCertificatedKey, 0);
+	}
+
+	public void deleteMailCertificationFlag(String email) {
+		String mailCertificatedKey = getMailCertificationKey(email);
+		redisTemplate.delete(mailCertificatedKey);
+	}
+
+	protected String getMailCertificationKey(String email) {
+		return "email" + ":" + email + "verifyFlag";
 	}
 
 	/**

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/repository/RedisRepository.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/repository/RedisRepository.java
@@ -18,6 +18,10 @@ public class RedisRepository {
 
 	@Value("${certification.message.expiration-seconds}")
 	private int messageExp;
+
+	@Value("${certification.mail.expiration-seconds}")
+	private int mailExp;
+
 	private final RedisTemplate<String, Object> redisTemplate;
 
 	/**
@@ -37,6 +41,23 @@ public class RedisRepository {
 		Duration expireDuration = Duration.ofSeconds(refreshExp);
 		valueOperations.set(phoneNumber, certificationNumber, expireDuration);
 	}
+
+	/**
+	 * 이메일 인증 번호 저장
+	 */
+	public void saveCertificationEmailNumber(String email, String certificationNumber) {
+		ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+		Duration expireDuration = Duration.ofSeconds(mailExp);
+		valueOperations.set(email, certificationNumber, expireDuration);
+	}
+
+	/**
+	 * 이메일 인증 유효시간 반환
+	 */
+	public int getMailExp() {
+		return mailExp;
+	}
+
 	/**
 	 * 인증 번호 가져 오기
 	 */

--- a/core/domain/src/main/resources/application-domain.yml
+++ b/core/domain/src/main/resources/application-domain.yml
@@ -2,5 +2,7 @@ jwt:
   refresh-expiration-seconds: 36000 # 리프래쉬 토큰 만료시간: 10시간
 
 certification:
+  mail:
+    expiration-seconds : 600 # 이메일 인증 만료 시간
   message:
     expiration-seconds : 180 # 인증 만료시간

--- a/core/infra/src/main/resources/application-infra.yml
+++ b/core/infra/src/main/resources/application-infra.yml
@@ -10,10 +10,11 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: validate
+      ddl-auto: none
     defer-datasource-initialization: true
     properties:
-      dialect: org.hibernate.dialect.MySQLDialect
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
 
 
   data:
@@ -24,8 +25,7 @@ spring:
   sql:
     init:
       # main 함수 실행 시, schema.sql 작동하도록 멀티 모듈 환경에서 classpath: 설정하기
-      #mode: always
-      #schema-locations: classpath:schema.sql
+      mode: always
 
 logging:
   level:

--- a/core/infra/src/testFixtures/java/com/backtothefuture/infra/config/BfTestConfig.java
+++ b/core/infra/src/testFixtures/java/com/backtothefuture/infra/config/BfTestConfig.java
@@ -18,7 +18,7 @@ import io.github.cdimascio.dotenv.DotenvEntry;
 public abstract class BfTestConfig {
 	@Container
 	static MySQLContainer<?> mySQLContainer = new MySQLContainer<>("mysql:8")
-		.withUsername("test_user")
+		.withUsername("root")
 		.withPassword("1234")
 		.withDatabaseName("");
 
@@ -31,7 +31,7 @@ public abstract class BfTestConfig {
 		registry.add("spring.datasource.url", mySQLContainer::getJdbcUrl);
 		registry.add("spring.datasource.username", mySQLContainer::getUsername);
 		registry.add("spring.datasource.password", mySQLContainer::getPassword);
-		registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
 	}
 
 	@DynamicPropertySource

--- a/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
+++ b/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
@@ -117,7 +117,9 @@ public class SpringSecurityConfig {
                 antMatcher(GET, "/store/{storeId}/products/{productId}"),        // 상품 단건 조회 API
                 antMatcher(GET, "/products"),                           // 상품 전체 조회 API
                 antMatcher(GET, "/certificate/message/**"), // 인증 번호 받기
-                antMatcher(POST, "/certificate/message") // 인증 번호 검증
+                antMatcher(POST, "/certificate/message"), // 인증 번호 검증
+                antMatcher(POST, "/certificate/email"), // 메일 인증번호 전송
+                antMatcher(GET, "/certificate/email") // 인증 번호 검증
         );
 
         return requestMatchers.toArray(RequestMatcher[]::new);

--- a/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
+++ b/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
@@ -119,7 +119,8 @@ public class SpringSecurityConfig {
                 antMatcher(GET, "/certificate/message/**"), // 인증 번호 받기
                 antMatcher(POST, "/certificate/message"), // 인증 번호 검증
                 antMatcher(POST, "/certificate/email"), // 메일 인증번호 전송
-                antMatcher(GET, "/certificate/email") // 인증 번호 검증
+                antMatcher(GET, "/certificate/email"), // 인증 번호 검증
+                antMatcher(GET, "/email/{email}/status") // 메일 인증 여부 확인
         );
 
         return requestMatchers.toArray(RequestMatcher[]::new);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,8 @@ services:
       SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/test
       SPRING_REDIS_HOST: redis
       SPRING_REDIS_PORT: 6379
+      MAIL_USERNAME: ${MAIL_USERNAME}
+      MAIL_PASSWORD: ${MAIL_PASSWORD}
     depends_on:
       db:
         condition: service_healthy

--- a/docs/openapi/event-openapi.yaml
+++ b/docs/openapi/event-openapi.yaml
@@ -7,6 +7,56 @@ servers:
 - url: http://localhost:8084/v1
 tags: []
 paths:
+  /certificate/email:
+    get:
+      tags:
+      - certificate
+      summary: 인증 메일 검증
+      description: "인증 메일 검증 API입니다. 메일 수신자가 링크를 클릭하고, 이 API를 통해 인증하게 됩니다."
+      operationId: verify-certificate-email
+      responses:
+        "200":
+          description: "200"
+          content:
+            text/html;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/certificate-email486549215'
+              examples:
+                verify-certificate-email:
+                  value: |-
+                    <!DOCTYPE html>
+                    <html>
+                    <head>
+                        <title>인증 결과</title>
+                        <meta charset="utf-8">
+                    </head>
+                        <h1>성공적으로 인증되었습니다. 앱 화면으로 돌아가 주세요.</h1>
+                    </html>
+    post:
+      tags:
+      - certificate
+      summary: 인증 메일 전송 API
+      description: 인증 메일 전송 API 입니다.
+      operationId: send-certificate-email
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/certificate-email486549215'
+            examples:
+              send-certificate-email:
+                value: "{\"email\":\"test@example.com\"}"
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/[response] send-certificate-email"
+              examples:
+                send-certificate-email:
+                  value: "{\"code\":200,\"message\":\"정상 처리되었습니다.\",\"data\":{\"mail_expiration_seconds\"\
+                    :600}}"
   /certificate/message:
     post:
       tags:
@@ -22,7 +72,7 @@ paths:
             examples:
               verify-certificate-number:
                 value: "{\"phoneNumber\":[\"010\",\"1234\",\"5678\"],\"certificationNumber\"\
-                  :\"158745\"}"
+                  :\"418790\"}"
       responses:
         "200":
           description: "200"
@@ -57,11 +107,36 @@ paths:
               examples:
                 get-certificate-number:
                   value: "{\"code\":201,\"message\":\"정상적으로 생성되었습니다.\",\"data\":{\"\
-                    certification_number\":\"402195\"}}"
+                    certification_number\":\"374645\"}}"
+  /certificate/email/{email}/status:
+    get:
+      tags:
+      - certificate
+      summary: 이메일 인증 상태 확인
+      description: 이메일 인증 상태 확인 API입니다.
+      operationId: check-certificate-email-status
+      parameters:
+      - name: email
+        in: path
+        description: ""
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/[response] check-certificate-email-status"
+              examples:
+                check-certificate-email-status:
+                  value: "{\"code\":200,\"message\":\"정상 처리되었습니다.\",\"data\":{\"is_certificated\"\
+                    :true}}"
 components:
   schemas:
-    '[response] verify-certificate-number':
-      title: "[response] verify-certificate-number"
+    '[response] send-certificate-email':
+      title: "[response] send-certificate-email"
       required:
       - code
       - message
@@ -70,6 +145,35 @@ components:
         code:
           type: number
           description: 응답 코드
+        data:
+          required:
+          - mail_expiration_seconds
+          type: object
+          properties:
+            mail_expiration_seconds:
+              type: number
+              description: 인증 만료 시간(초)
+        message:
+          type: string
+          description: 응답 메시지
+    '[response] check-certificate-email-status':
+      title: "[response] check-certificate-email-status"
+      required:
+      - code
+      - message
+      type: object
+      properties:
+        code:
+          type: number
+          description: 응답 코드
+        data:
+          required:
+          - is_certificated
+          type: object
+          properties:
+            is_certificated:
+              type: boolean
+              description: "인증 여부. true: 인증 / false: 미인증"
         message:
           type: string
           description: 응답 메시지
@@ -94,6 +198,21 @@ components:
         message:
           type: string
           description: 응답 메시지
+    '[response] verify-certificate-number':
+      title: "[response] verify-certificate-number"
+      required:
+      - code
+      - message
+      type: object
+      properties:
+        code:
+          type: number
+          description: 응답 코드
+        message:
+          type: string
+          description: 응답 메시지
+    certificate-email486549215:
+      type: object
     '[request] verify-certificate-number':
       title: "[request] verify-certificate-number"
       required:


### PR DESCRIPTION
## 📝 작업 내용
- 인증 메일 전송 api 추가
- 인증 메일 검증 api 추가
  - 이 api는 프론트에서 활용하는 api가 아니라, 메일 수신자가 클릭하는 링크 입니다.
- 인증 메일 검증 상태 확인 api 추가
  - 인증 완료 시 true, 미완료시 false
- #86 관련 버그 수정 :: 자세한건 해당 이슈에 적어놓았습니다. 
- 

## 💬 ETC.
- 메일 전송 결과
<img width="1108" alt="image" src="https://github.com/backtothefuture-team/backtothefuture-backend/assets/67352902/32e5d4b4-950e-425e-ba20-95cd3fc68ee9">

- 성공 시
<img width="1063" alt="image" src="https://github.com/backtothefuture-team/backtothefuture-backend/assets/67352902/3d23ea6e-fecd-421c-bb9a-d79d0e70f41e">

- 실패 시
<img width="1118" alt="image" src="https://github.com/backtothefuture-team/backtothefuture-backend/assets/67352902/3c9ac73e-d5c3-42a0-981a-5a4dc1065454">

- API 문서
<img width="1460" alt="image" src="https://github.com/backtothefuture-team/backtothefuture-backend/assets/67352902/4844c1d8-d1bb-410d-9710-c9be17cbd62c">


## #️⃣ 연관된 이슈
resolves: #46, #86