### PR TITLE
feat: 영업 시작/종료 시간, 예약 시간 기능 추가

### DIFF
--- a/api/store/src/main/java/com/backtothefuture/store/dto/request/ReservationRequestDto.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/request/ReservationRequestDto.java
@@ -4,15 +4,23 @@ package com.backtothefuture.store.dto.request;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalTime;
 import java.util.List;
+
 @Builder
 public record ReservationRequestDto(
 
-        @NotNull(message = "가게 Id 값은 필수입니다.")
-        Long storeId,
+    @NotNull(message = "가게 Id 값은 필수입니다.")
+    Long storeId,
 
-        @Size(min = 1, message = "주문 품목은 최소 1개 이상입니다.")
-        List<ReservationRequestItemDto> orderRequestItems
+    @Size(min = 1, message = "주문 품목은 최소 1개 이상입니다.")
+    List<ReservationRequestItemDto> orderRequestItems,
+
+    @DateTimeFormat(pattern = "HH:mm")
+    @NotNull(message = "예약 시간은 필수 입니다.")
+    LocalTime reservationTime
 ) {
+
 }

--- a/api/store/src/main/java/com/backtothefuture/store/dto/request/StoreRegisterDto.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/request/StoreRegisterDto.java
@@ -1,5 +1,6 @@
 package com.backtothefuture.store.dto.request;
 
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -8,44 +9,57 @@ import com.backtothefuture.domain.store.Store;
 import com.backtothefuture.store.annotation.NumericStringList;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Builder
 public record StoreRegisterDto(
-	@NotBlank(message = "가게이름은 필수 항목입니다.")
-	@Size(max = 20, message = "가게이름은 최대 20자 이하로 입력해주세요.")
-	String name,
+    @NotBlank(message = "가게이름은 필수 항목입니다.")
+    @Size(max = 20, message = "가게이름은 최대 20자 이하로 입력해주세요.")
+    String name,
 
-	@NotBlank(message = "가게설명은 필수 항목입니다.")
-	@Size(max = 50, message = "가게설명은 최대 50자 이하로 입력해주세요.")
-	String description,
+    @NotBlank(message = "가게설명은 필수 항목입니다.")
+    @Size(max = 50, message = "가게설명은 최대 50자 이하로 입력해주세요.")
+    String description,
 
-	@NotBlank(message = "가게위치는 필수 항목입니다.")
-	@Size(max = 50, message = "가게위치는 최대 50자 이하로 입력해주세요.")
-	String location,
+    @NotBlank(message = "가게위치는 필수 항목입니다.")
+    @Size(max = 50, message = "가게위치는 최대 50자 이하로 입력해주세요.")
+    String location,
 
-	@NumericStringList(message = "연락처는 숫자만 입력할 수 있습니다.")
-	List<String> contact,
+    @NumericStringList(message = "연락처는 숫자만 입력할 수 있습니다.")
+    List<String> contact,
 
-	String image
+    String image,
+
+    @DateTimeFormat(pattern = "HH:mm")
+    @NotNull(message = "오픈 시간은 필수 입니다.")
+    LocalTime startTime,
+
+    @DateTimeFormat(pattern = "HH:mm")
+    @NotNull(message = "마감 시간은 필수 입니다.")
+    LocalTime endTime
 ) {
-	public static Store toEntity(StoreRegisterDto storeRegisterDto, Member member){
-		String contact = Optional.ofNullable(storeRegisterDto.contact())
-			.map(num ->String.join("-", num))
-			.orElse("");
 
-		String image = Optional.ofNullable(storeRegisterDto.image()).orElse("");
+    public static Store toEntity(StoreRegisterDto storeRegisterDto, Member member) {
+        String contact = Optional.ofNullable(storeRegisterDto.contact())
+            .map(num -> String.join("-", num))
+            .orElse("");
 
-		return Store.builder()
-			.name(storeRegisterDto.name())
-			.description(storeRegisterDto.description())
-			.location(storeRegisterDto.location())
-			.contact(contact)
-			.image(image)
-			.member(member)
-			.build();
-	}
+        String image = Optional.ofNullable(storeRegisterDto.image()).orElse("");
+
+        return Store.builder()
+            .name(storeRegisterDto.name())
+            .description(storeRegisterDto.description())
+            .location(storeRegisterDto.location())
+            .contact(contact)
+            .image(image)
+            .member(member)
+            .startTime(storeRegisterDto.startTime())
+            .endTime(storeRegisterDto.endTime())
+            .build();
+    }
 
 
 }

--- a/api/store/src/main/java/com/backtothefuture/store/service/ReservationService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/ReservationService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
+import java.time.LocalTime;
 import java.util.List;
 
 import static com.backtothefuture.domain.common.enums.MemberErrorCode.*;
@@ -50,16 +51,24 @@ public class ReservationService {
     public Long makeReservation(Long memberId, ReservationRequestDto dto) {
 
         Member member = memberRepository.findById(memberId)  // 현재 회원 조회
-                .orElseThrow(() -> new MemberException(NOT_FIND_MEMBER_ID));
+            .orElseThrow(() -> new MemberException(NOT_FIND_MEMBER_ID));
 
         Store store = storeRepository.findById(dto.storeId())  // 주문하고자 하는 가게 조회
-                .orElseThrow(() -> new StoreException(NOT_FOUND_STORE_ID));
+            .orElseThrow(() -> new StoreException(NOT_FOUND_STORE_ID));
+
+        if (!validateReservationTime(dto.reservationTime(),
+            store.getEndTime())) // 영업 종료 30분 이전인지 판단
+        {
+            throw new ReservationException(NOT_VALID_RESERVATION_TIME);
+        }
 
         Reservation reservation = Reservation.builder()
-                .store(store)
-                .member(member)
-                .totalPrice(0)
-                .build();
+            .store(store)
+            .member(member)
+            .totalPrice(0)
+            .reservationTime(dto.reservationTime())
+            .build();
+
         reservationRepository.save(reservation);
 
         updateStock(dto, reservation);
@@ -68,10 +77,11 @@ public class ReservationService {
     }
 
     @Transactional(readOnly = true)
-    public List<ReservationResponseDto> getReservation(UserDetailsImpl userDetails, Long reservationId) {
+    public List<ReservationResponseDto> getReservation(UserDetailsImpl userDetails,
+        Long reservationId) {
         //TODO: memberId 비교해서 권한 체크
         List<ReservationResponseDto> reservationResponseDto =
-                customReservationRepository.getReservation(userDetails.getId(), reservationId);
+            customReservationRepository.getReservation(userDetails.getId(), reservationId);
 
         reservationResponseDto.forEach(ReservationResponseDto::calculateTotalPrice);
 
@@ -81,14 +91,16 @@ public class ReservationService {
     @Transactional
     public void cancelReservation(UserDetailsImpl userDetails, Long reservationId) {
         //TODO: memberId 비교해서 권한 체크
-        List<ReservationProduct> reservationProducts = reservationProductRepository.findAllByReservation(reservationId);
+        List<ReservationProduct> reservationProducts = reservationProductRepository.findAllByReservation(
+            reservationId);
 
-        if(reservationProducts.size() == 0)
+        if (reservationProducts.size() == 0) {
             throw new ReservationException(NOT_FOUND_RESERVATION_PRODUCT);
+        }
 
-        reservationProducts.forEach((reservationProduct)->{
+        reservationProducts.forEach((reservationProduct) -> {
             Product product = productRepository.findById(reservationProduct.getProduct().getId())
-                    .orElseThrow(() -> new ProductException(NOT_FOUND_PRODUCT_ID));
+                .orElseThrow(() -> new ProductException(NOT_FOUND_PRODUCT_ID));
             product.updateStockWhenCancel(reservationProduct.getQuantity()); // 취소된 상품에 대해서 재고 증가
             reservationProductRepository.delete(reservationProduct); // 주문 상품 엔티티 삭제
         });
@@ -97,30 +109,36 @@ public class ReservationService {
     }
 
     /**
-     * 1. 상품 조회
-     * 2. 재고, 주문 수량 비교
-     * 3. 재고 차감
+     * 1. 상품 조회 2. 재고, 주문 수량 비교 3. 재고 차감
      */
     private void updateStock(ReservationRequestDto dto, Reservation reservation) {
 
         dto.orderRequestItems().forEach(itemDto -> {
 
-            Product product = productRepository.findProductWithPessimisticLockById(itemDto.productId())  // 주문하고자 하는 상품 조회
-                    .orElseThrow(() -> new ProductException(NOT_FOUND_PRODUCT_ID));
+            Product product = productRepository.findProductWithPessimisticLockById(
+                    itemDto.productId())  // 주문하고자 하는 상품 조회
+                .orElseThrow(() -> new ProductException(NOT_FOUND_PRODUCT_ID));
 
             if (product.getStockQuantity() < itemDto.quantity())  // 재고가 부족하면 예외 처리
+            {
                 throw new ReservationException(NOT_ENOUGH_STOCK_QUANTITY);
+            }
 
-            int price = product.updateStockWhenReserve(itemDto.quantity()); // 재고 차감하고 상품에 대한 주문 금액 반환
+            int price = product.updateStockWhenReserve(
+                itemDto.quantity()); // 재고 차감하고 상품에 대한 주문 금액 반환
             reservation.increaseTotalPrice(price); // 주문 금액 반영
 
             reservationProductRepository.save(
-                    ReservationProduct.builder()
-                            .reservation(reservation)
-                            .product(product)
-                            .quantity(itemDto.quantity())
-                            .build());
+                ReservationProduct.builder()
+                    .reservation(reservation)
+                    .product(product)
+                    .quantity(itemDto.quantity())
+                    .build());
         });
+    }
+
+    private boolean validateReservationTime(LocalTime reservationTime, LocalTime endTime) {
+        return reservationTime.plusMinutes(30).isBefore(endTime); // 예약 시간이 영업 종료 30분 이전인지 판단
     }
 
 }

--- a/api/store/src/main/resources/application.yml
+++ b/api/store/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   profiles:
-    include: domain, infra, security
-    active: dev
+    include: domain, infra, security, testContainers
+    active: dev, test
   jpa:
     open-in-view: false # view, Controller 단에서 Lazy를 사용하지 않음
     properties:

--- a/api/store/src/test/java/com/backtothefuture/store/controller/ReservationConcurrencyTest.java
+++ b/api/store/src/test/java/com/backtothefuture/store/controller/ReservationConcurrencyTest.java
@@ -25,10 +25,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
-
+import org.springframework.test.context.ActiveProfiles;
 import static com.backtothefuture.domain.common.enums.ProductErrorCode.NOT_FOUND_PRODUCT_ID;
 
 @SpringBootTest
+@ActiveProfiles("test")
 public class ReservationConcurrencyTest extends BfTestConfig {
 
     @Autowired

--- a/api/store/src/test/java/com/backtothefuture/store/controller/ReservationConcurrencyTest.java
+++ b/api/store/src/test/java/com/backtothefuture/store/controller/ReservationConcurrencyTest.java
@@ -46,52 +46,52 @@ public class ReservationConcurrencyTest extends BfTestConfig {
     void ReservationConcurrencyTest() throws InterruptedException {
         //given
         Member customer1 = Member.builder() // 고객1 생성
-            .name("이상민")
-            .authId(null)
-            .email("leesangmin@naver.com")
-            .status(StatusType.ACTIVE)
-            .provider(null)
-            .roles(RolesType.ROLE_USER)
-            .build();
+                .name("이상민")
+                .authId(null)
+                .email("leesangmin@naver.com")
+                .status(StatusType.ACTIVE)
+                .provider(null)
+                .roles(RolesType.ROLE_USER)
+                .build();
         memberRepository.save(customer1);
 
         Member owner = Member.builder()  // 가게 주인 생성
-            .name("owner")
-            .authId(null)
-            .email("email3@naver.com")
-            .status(StatusType.ACTIVE)
-            .provider(null)
-            .roles(RolesType.ROLE_STORE_OWNER)
-            .build();
+                .name("owner")
+                .authId(null)
+                .email("email3@naver.com")
+                .status(StatusType.ACTIVE)
+                .provider(null)
+                .roles(RolesType.ROLE_STORE_OWNER)
+                .build();
         memberRepository.save(owner);
 
         Store store = Store.builder()  // 가게 생성
-            .name("gs25")
-            .description("편의점입니다.")
-            .image("이미지 url")
-            .contact("010-0000-0000")
-            .location("서울")
-            .member(owner)
-            .startTime(LocalTime.of(10, 00))
-            .endTime(LocalTime.of(21, 00))
-            .build();
+                .name("gs25")
+                .description("편의점입니다.")
+                .image("이미지 url")
+                .contact("010-0000-0000")
+                .location("서울")
+                .member(owner)
+                .startTime(LocalTime.of(10, 00))
+                .endTime(LocalTime.of(21, 00))
+                .build();
         storeRepository.save(store);
 
         Product product = Product.builder()
-            .name("삼각김밥")
-            .description("삼각김밥입니다.")
-            .price(1000)
-            .stockQuantity(1000)
-            .thumbnail("nail test")
-            .store(store)
-            .build();
+                .name("삼각김밥")
+                .description("삼각김밥입니다.")
+                .price(1000)
+                .stockQuantity(1000)
+                .thumbnail("nail test")
+                .store(store)
+                .build();
         productRepository.save(product);
 
         ReservationRequestDto reservationRequestDto = ReservationRequestDto.builder()
-            .storeId(store.getId())
-            .orderRequestItems(List.of(new ReservationRequestItemDto(product.getId(), 6)))
-            .reservationTime(LocalTime.of(12, 00))
-            .build();
+                .storeId(store.getId())
+                .orderRequestItems(List.of(new ReservationRequestItemDto(product.getId(), 6)))
+                .reservationTime(LocalTime.of(12, 00))
+                .build();
 
         //when
         int threadCount = 200; // thread pool 속 thread 갯수
@@ -110,7 +110,7 @@ public class ReservationConcurrencyTest extends BfTestConfig {
                 try {
                     // 예약 실시
                     Long reservationId = reservationService.makeReservation(customer1.getId(),
-                        reservationRequestDto);
+                            reservationRequestDto);
                     // 성공 횟수 증가
                     successCount.getAndIncrement();
                 } catch (Exception e) {
@@ -125,7 +125,7 @@ public class ReservationConcurrencyTest extends BfTestConfig {
         productRepository.flush();
         //then
         Product findProduct = productRepository.findById(product.getId())
-            .orElseThrow(() -> new ProductException(NOT_FOUND_PRODUCT_ID));
+                .orElseThrow(() -> new ProductException(NOT_FOUND_PRODUCT_ID));
         Assertions.assertEquals(4, findProduct.getStockQuantity());
         Assertions.assertEquals(34, failureCount.get());
         Assertions.assertEquals(166, successCount.get());

--- a/api/store/src/test/java/com/backtothefuture/store/controller/ReservationControllerTest.java
+++ b/api/store/src/test/java/com/backtothefuture/store/controller/ReservationControllerTest.java
@@ -1,5 +1,6 @@
 package com.backtothefuture.store.controller;
 
+import com.backtothefuture.infra.config.BfTestConfig;
 import com.backtothefuture.store.dto.response.ReservationResponseDto;
 import com.backtothefuture.security.annotation.WithMockCustomUser;
 import com.backtothefuture.store.dto.request.ReservationRequestDto;
@@ -29,6 +30,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.time.LocalTime;
 import java.util.List;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
@@ -43,7 +45,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 @ExtendWith(RestDocumentationExtension.class)
 @SpringBootTest
 @ContextConfiguration
-class ReservationControllerTest {
+class ReservationControllerTest extends BfTestConfig {
 
 
     private MockMvc mockMvc;
@@ -55,10 +57,11 @@ class ReservationControllerTest {
     private ObjectMapper objectMapper;
 
     @BeforeEach
-    void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
+    void setUp(WebApplicationContext webApplicationContext,
+        RestDocumentationContextProvider restDocumentation) {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-                .apply(documentationConfiguration(restDocumentation))
-                .build();
+            .apply(documentationConfiguration(restDocumentation))
+            .build();
     }
 
     @Test
@@ -71,38 +74,47 @@ class ReservationControllerTest {
         Long product2Id = 2L;
 
         ReservationRequestDto reservationRequestDto = ReservationRequestDto.builder()
-                .storeId(storeId)
-                .orderRequestItems(List.of(new ReservationRequestItemDto(product1Id, 1),
-                        new ReservationRequestItemDto(product2Id, 1)))
-                .build();
+            .storeId(storeId)
+            .orderRequestItems(List.of(new ReservationRequestItemDto(product1Id, 1),
+                new ReservationRequestItemDto(product2Id, 1)))
+            .reservationTime(LocalTime.of(12, 00))
+            .build();
 
         // TODO: 아래 코드가 테스트의 효과가 있는지 궁금합니다!
-        when(mockReservationService.makeReservation(anyLong(), eq(reservationRequestDto))).thenReturn(1L);
+        when(mockReservationService.makeReservation(anyLong(),
+            eq(reservationRequestDto))).thenReturn(
+            1L);
 
         this.mockMvc.perform(RestDocumentationRequestBuilders.post("/reservations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(reservationRequestDto))
-                        .header("Authorization", "Bearer ${JWT Token}")
-                        .with(csrf()))
-                .andExpect(MockMvcResultMatchers.status().isCreated())
-                .andDo(document("make-reservation",
-                        resource(ResourceSnippetParameters.builder()
-                                .description("구매자 예약하기 API입니다.")
-                                .tags("reservations")
-                                .summary("구매자 예약 API")
-                                .requestFields(
-                                        fieldWithPath("storeId").type(SimpleType.NUMBER).description("가게 ID 값입니다."),
-                                        fieldWithPath("orderRequestItems[].productId").type(SimpleType.NUMBER).description("상품 ID 값입니다."),
-                                        fieldWithPath("orderRequestItems[].quantity").type(SimpleType.NUMBER).description("주문한 수량 값입니다.")
-                                )
-                                .requestSchema(Schema.schema("[request] make-reservation"))
-                                .responseFields(
-                                        fieldWithPath("code").type(SimpleType.NUMBER).description("HttpStatusCode 입니다."),
-                                        fieldWithPath("message").type(SimpleType.STRING).description("응답 메시지 입니다."),
-                                        fieldWithPath("data.reservation_id").type(SimpleType.NUMBER).description("생성된 주문 ID 입니다.")
-                                )
-                                .responseSchema(Schema.schema("[response] make-reservation")).build()
-                        )));
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(reservationRequestDto))
+                .header("Authorization", "Bearer ${JWT Token}")
+                .with(csrf()))
+            .andExpect(MockMvcResultMatchers.status().isCreated())
+            .andDo(document("make-reservation",
+                resource(ResourceSnippetParameters.builder()
+                    .description("구매자 예약하기 API입니다.")
+                    .tags("reservations")
+                    .summary("구매자 예약 API")
+                    .requestFields(
+                        fieldWithPath("storeId").type(SimpleType.NUMBER).description("가게 ID 값입니다."),
+                        fieldWithPath("orderRequestItems[].productId").type(SimpleType.NUMBER)
+                            .description("상품 ID 값입니다."),
+                        fieldWithPath("orderRequestItems[].quantity").type(SimpleType.NUMBER)
+                            .description("주문한 수량 값입니다."),
+                        fieldWithPath("reservationTime").type(SimpleType.STRING)
+                            .description("예약 시간입니다. 'HH:mm' 형태입니다.")
+                    )
+                    .requestSchema(Schema.schema("[request] make-reservation"))
+                    .responseFields(
+                        fieldWithPath("code").type(SimpleType.NUMBER)
+                            .description("HttpStatusCode 입니다."),
+                        fieldWithPath("message").type(SimpleType.STRING).description("응답 메시지 입니다."),
+                        fieldWithPath("data.reservation_id").type(SimpleType.NUMBER)
+                            .description("생성된 주문 ID 입니다.")
+                    )
+                    .responseSchema(Schema.schema("[response] make-reservation")).build()
+                )));
 
     }
 
@@ -114,34 +126,41 @@ class ReservationControllerTest {
         Long reservationId = 1L;
 
         List<ReservationResponseDto> reservationResponseDto = List.of(
-                new ReservationResponseDto("product1", 1, 1000),
-                new ReservationResponseDto("product2", 2, 2000)
+            new ReservationResponseDto("product1", 1, 1000),
+            new ReservationResponseDto("product2", 2, 2000)
         );
 
-        when(mockReservationService.getReservation(any(), eq(reservationId))).thenReturn(reservationResponseDto);
+        when(mockReservationService.getReservation(any(), eq(reservationId))).thenReturn(
+            reservationResponseDto);
 
-        this.mockMvc.perform(RestDocumentationRequestBuilders.get("/reservations/{reservationId}", reservationId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(reservationResponseDto))
-                        .header("Authorization", "Bearer ${JWT Token}"))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andDo(document("get-reservation",
-                        resource(ResourceSnippetParameters.builder()
-                                .description("구매자 예약 조회 API입니다.")
-                                .tags("reservations")
-                                .summary("구매자 예약 조회 API")
-                                .pathParameters(
-                                        parameterWithName("reservationId").type(SimpleType.NUMBER).description("예약 ID")
-                                )
-                                .responseFields(
-                                        fieldWithPath("code").type(SimpleType.NUMBER).description("HttpStatusCode 입니다."),
-                                        fieldWithPath("message").type(SimpleType.STRING).description("응답 메시지 입니다."),
-                                        fieldWithPath("data[].name").type(SimpleType.STRING).description("상품 이름입니다."),
-                                        fieldWithPath("data[].count").type(SimpleType.STRING).description("주문된 각 상품의 수량입니다."),
-                                        fieldWithPath("data[].price").type(SimpleType.STRING).description("주문된 각 상품의 금액입니다.")
-                                )
-                                .responseSchema(Schema.schema("[response] make-reservation")).build()
-                        )));
+        this.mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/reservations/{reservationId}", reservationId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(reservationResponseDto))
+                    .header("Authorization", "Bearer ${JWT Token}"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andDo(document("get-reservation",
+                resource(ResourceSnippetParameters.builder()
+                    .description("구매자 예약 조회 API입니다.")
+                    .tags("reservations")
+                    .summary("구매자 예약 조회 API")
+                    .pathParameters(
+                        parameterWithName("reservationId").type(SimpleType.NUMBER)
+                            .description("예약 ID")
+                    )
+                    .responseFields(
+                        fieldWithPath("code").type(SimpleType.NUMBER)
+                            .description("HttpStatusCode 입니다."),
+                        fieldWithPath("message").type(SimpleType.STRING).description("응답 메시지 입니다."),
+                        fieldWithPath("data[].name").type(SimpleType.STRING)
+                            .description("상품 이름입니다."),
+                        fieldWithPath("data[].count").type(SimpleType.STRING)
+                            .description("주문된 각 상품의 수량입니다."),
+                        fieldWithPath("data[].price").type(SimpleType.STRING)
+                            .description("주문된 각 상품의 금액입니다.")
+                    )
+                    .responseSchema(Schema.schema("[response] make-reservation")).build()
+                )));
     }
 
     @Test
@@ -152,25 +171,28 @@ class ReservationControllerTest {
         Long reservationId = 1L;
         doNothing().when(mockReservationService).cancelReservation(any(), eq(reservationId));
 
-        this.mockMvc.perform(RestDocumentationRequestBuilders.delete("/reservations/{reservationId}", reservationId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "Bearer ${JWT Token}"))
-                .andExpect(MockMvcResultMatchers.status().isNoContent())
-                .andDo(document("cancel-reservation",
-                        resource(ResourceSnippetParameters.builder()
-                                .description("구매자 예약 취소 API입니다.")
-                                .tags("reservations")
-                                .summary("구매자 예약 취소 API")
-                                .pathParameters(
-                                        parameterWithName("reservationId").type(SimpleType.NUMBER).description("예약 ID")
-                                )
-                                .responseFields(
-                                        fieldWithPath("code").type(SimpleType.NUMBER).description("HttpStatusCode 입니다."),
-                                        fieldWithPath("message").type(SimpleType.STRING).description("응답 메시지 입니다."),
-                                        fieldWithPath("data").type(SimpleType.STRING).description("NO_CONTENT")
-                                )
-                                .responseSchema(Schema.schema("[response] cancel-reservation")).build()
-                        )));
+        this.mockMvc.perform(
+                RestDocumentationRequestBuilders.delete("/reservations/{reservationId}", reservationId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer ${JWT Token}"))
+            .andExpect(MockMvcResultMatchers.status().isNoContent())
+            .andDo(document("cancel-reservation",
+                resource(ResourceSnippetParameters.builder()
+                    .description("구매자 예약 취소 API입니다.")
+                    .tags("reservations")
+                    .summary("구매자 예약 취소 API")
+                    .pathParameters(
+                        parameterWithName("reservationId").type(SimpleType.NUMBER)
+                            .description("예약 ID")
+                    )
+                    .responseFields(
+                        fieldWithPath("code").type(SimpleType.NUMBER)
+                            .description("HttpStatusCode 입니다."),
+                        fieldWithPath("message").type(SimpleType.STRING).description("응답 메시지 입니다."),
+                        fieldWithPath("data").type(SimpleType.STRING).description("NO_CONTENT")
+                    )
+                    .responseSchema(Schema.schema("[response] cancel-reservation")).build()
+                )));
 
     }
 }

--- a/api/store/src/test/java/com/backtothefuture/store/controller/StoreControllerTest.java
+++ b/api/store/src/test/java/com/backtothefuture/store/controller/StoreControllerTest.java
@@ -7,6 +7,7 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.epages.restdocs.apispec.SimpleType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(RestDocumentationExtension.class)
 @SpringBootTest
 class StoreControllerTest extends BfTestConfig {
+
     private MockMvc mockMvc;
 
     @MockBean
@@ -46,12 +48,13 @@ class StoreControllerTest extends BfTestConfig {
     private ObjectMapper objectMapper;
 
     @BeforeEach
-    void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
+    void setUp(WebApplicationContext webApplicationContext,
+        RestDocumentationContextProvider restDocumentation) {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-                .apply(documentationConfiguration(restDocumentation))
-                // TODO: JWT 토큰 인증 처리 -> 실제 토큰을 발급받아 사용 or mocking(현재적용됨)
-                //.apply(springSecurity()) // Spring Security 설정 적용
-                .build();
+            .apply(documentationConfiguration(restDocumentation))
+            // TODO: JWT 토큰 인증 처리 -> 실제 토큰을 발급받아 사용 or mocking(현재적용됨)
+            //.apply(springSecurity()) // Spring Security 설정 적용
+            .build();
     }
 
     @Test
@@ -61,43 +64,55 @@ class StoreControllerTest extends BfTestConfig {
         // given
         Long storeId = 1L;
         StoreRegisterDto storeRegisterDto = StoreRegisterDto.builder()
-                .name("가게 이름")
-                .description("가게 설명")
-                .location("가게 위치")
-                .contact(List.of("010", "0000", "0000"))
-                .image("이미지 url")
-                .build();
+            .name("가게 이름")
+            .description("가게 설명")
+            .location("가게 위치")
+            .contact(List.of("010", "0000", "0000"))
+            .image("이미지 url")
+            .startTime(LocalTime.of(10, 00))
+            .endTime(LocalTime.of(21, 00))
+            .build();
         when(storeService.registerStore(storeRegisterDto)).thenReturn(1L);
 
         this.mockMvc.perform(post("/stores")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(storeRegisterDto))
-                        .header("Authorization", "Bearer ${JWT Token}"))
-                .andExpect(status().isCreated())
-                .andDo(document("register-store",
-                        resource(ResourceSnippetParameters.builder()
-                                .description("가게 등록 API 입니다.")
-                                .tags("stores")
-                                .summary("가게 등록 API")
-                                // request
-                                .requestHeaders(
-                                        headerWithName("Authorization").type(SimpleType.STRING).description("JWT 인증 토큰. 'Bearer ${Jwt Token}' 형식으로 입력해 주세요.")
-                                )
-                                .requestFields(
-                                        fieldWithPath("name").type(SimpleType.STRING).description("가게 이름입니다."),
-                                        fieldWithPath("description").type(SimpleType.STRING).description("가게 상세 설명입니다."),
-                                        fieldWithPath("location").type(SimpleType.NUMBER).description("가게 위치입니다."),
-                                        fieldWithPath("contact").type(JsonFieldType.ARRAY).optional().description("연락처입니다. 문자열 배열로 입력해주세요.").optional(),
-                                        fieldWithPath("image").type(SimpleType.STRING).optional().description("썸네일 이미지 입니다.")
-                                )
-                                .requestSchema(Schema.schema("[request] store-register"))
-                                // response
-                                .responseFields(
-                                        fieldWithPath("code").type(SimpleType.NUMBER).description("HttpStatusCode 입니다."),
-                                        fieldWithPath("message").type(SimpleType.STRING).description("응답 메시지 입니다."),
-                                        fieldWithPath("data.store_id").type(SimpleType.NUMBER).description("생성된 가게 ID 입니다.")
-                                )
-                                .responseSchema(Schema.schema("[response] store-register")).build()
-                        )));
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(storeRegisterDto))
+                .header("Authorization", "Bearer ${JWT Token}"))
+            .andExpect(status().isCreated())
+            .andDo(document("register-store",
+                resource(ResourceSnippetParameters.builder()
+                    .description("가게 등록 API 입니다.")
+                    .tags("stores")
+                    .summary("가게 등록 API")
+                    // request
+                    .requestHeaders(
+                        headerWithName("Authorization").type(SimpleType.STRING)
+                            .description("JWT 인증 토큰. 'Bearer ${Jwt Token}' 형식으로 입력해 주세요.")
+                    )
+                    .requestFields(
+                        fieldWithPath("name").type(SimpleType.STRING).description("가게 이름입니다."),
+                        fieldWithPath("description").type(SimpleType.STRING)
+                            .description("가게 상세 설명입니다."),
+                        fieldWithPath("location").type(SimpleType.NUMBER).description("가게 위치입니다."),
+                        fieldWithPath("contact").type(JsonFieldType.ARRAY).optional()
+                            .description("연락처입니다. 문자열 배열로 입력해주세요.").optional(),
+                        fieldWithPath("image").type(SimpleType.STRING).optional()
+                            .description("썸네일 이미지 입니다."),
+                        fieldWithPath("startTime").type(SimpleType.STRING).optional()
+                            .description("오픈시간입니다. HH:mm 형태"),
+                        fieldWithPath("endTime").type(SimpleType.STRING).optional()
+                            .description("마감시간입니다. HH:mm 형태")
+                    )
+                    .requestSchema(Schema.schema("[request] store-register"))
+                    // response
+                    .responseFields(
+                        fieldWithPath("code").type(SimpleType.NUMBER)
+                            .description("HttpStatusCode 입니다."),
+                        fieldWithPath("message").type(SimpleType.STRING).description("응답 메시지 입니다."),
+                        fieldWithPath("data.store_id").type(SimpleType.NUMBER)
+                            .description("생성된 가게 ID 입니다.")
+                    )
+                    .responseSchema(Schema.schema("[response] store-register")).build()
+                )));
     }
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/enums/ReservationErrorCode.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/enums/ReservationErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum ReservationErrorCode implements BaseErrorCode {
 
     NOT_ENOUGH_STOCK_QUANTITY(400, "재고가 충분하지 않습니다.", HttpStatus.BAD_REQUEST),
-    NOT_FOUND_RESERVATION_PRODUCT(400, "주문 id에 해당하는 주문 상품이 없습니다.", HttpStatus.BAD_REQUEST);
+    NOT_FOUND_RESERVATION_PRODUCT(400, "주문 id에 해당하는 주문 상품이 없습니다.", HttpStatus.BAD_REQUEST),
+    NOT_VALID_RESERVATION_TIME(400, "적절한 예약 시간이 아닙니다.", HttpStatus.BAD_REQUEST);
 
     private final int errorCode;
     private final String errorMessage;

--- a/core/domain/src/main/java/com/backtothefuture/domain/reservation/Reservation.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/reservation/Reservation.java
@@ -5,6 +5,9 @@ import com.backtothefuture.domain.member.Member;
 import com.backtothefuture.domain.store.Store;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -27,6 +30,9 @@ public class Reservation extends MutableBaseEntity {
     private Store store;
 
     private Integer totalPrice; // 주문 총 금액
+
+    @DateTimeFormat(pattern = "HH:mm")
+    private LocalTime reservationTime;
 
     public void increaseTotalPrice(int price) {
         this.totalPrice += price;

--- a/core/domain/src/main/java/com/backtothefuture/domain/store/Store.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/store/Store.java
@@ -18,29 +18,37 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalTime;
+
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Store extends MutableBaseEntity {
-	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "store_id")
-	private Long id;
 
-	private String name; 		// 가게 이름
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "store_id")
+    private Long id;
 
-	@Lob
-	@Column(columnDefinition = "TEXT")
-	private String description; // 가게 설명
+    private String name;        // 가게 이름
 
-	private String location;	// 가게 위치
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String description; // 가게 설명
 
-	private String contact;		// 연락처
+    private String location;    // 가게 위치
 
-	private String image;		// 가게 이미지
+    private String contact;        // 연락처
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id")
-	private Member member;		// 회원
+    private String image;        // 가게 이미지
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;        // 회원
+
+    private LocalTime startTime; // 영업 시작 시간
+
+    private LocalTime endTime; // 영업 종료 시간
 }

--- a/core/infra/src/main/resources/application-testContainers.yml
+++ b/core/infra/src/main/resources/application-testContainers.yml
@@ -1,7 +1,7 @@
 spring:
   config:
     activate:
-      on-profile: dev
+      on-profile: test
   datasource:
     url: jdbc:mysql://localhost:3306/test
     username: root
@@ -11,7 +11,6 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: none
-    defer-datasource-initialization: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
@@ -22,9 +21,6 @@ spring:
       # docker container 시작 시 환경 변수를 전달 받도록 한다.
       host: ${SPRING_REDIS_HOST:localhost} # 기본값을 localhost로 설정
       port: ${SPRING_REDIS_PORT:6379} # 기본값을 6379로 설정
-  sql:
-    init:
-      mode: always
 
 logging:
   level:

--- a/core/infra/src/testFixtures/java/com/backtothefuture/infra/config/BfTestConfig.java
+++ b/core/infra/src/testFixtures/java/com/backtothefuture/infra/config/BfTestConfig.java
@@ -20,7 +20,7 @@ public abstract class BfTestConfig {
 	static MySQLContainer<?> mySQLContainer = new MySQLContainer<>("mysql:8")
 		.withUsername("root")
 		.withPassword("1234")
-		.withDatabaseName("");
+		.withDatabaseName("test");
 
 	@Container
 	static GenericContainer<?> redisContainer = new GenericContainer<>("redis:5.0.3-alpine")

--- a/core/infra/src/testFixtures/java/com/backtothefuture/infra/config/BfTestConfig.java
+++ b/core/infra/src/testFixtures/java/com/backtothefuture/infra/config/BfTestConfig.java
@@ -1,8 +1,5 @@
 package com.backtothefuture.infra.config;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -12,42 +9,43 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import io.github.cdimascio.dotenv.Dotenv;
-import io.github.cdimascio.dotenv.DotenvEntry;
+
 
 @Testcontainers
 public abstract class BfTestConfig {
-	@Container
-	static MySQLContainer<?> mySQLContainer = new MySQLContainer<>("mysql:8")
-		.withUsername("root")
-		.withPassword("1234")
-		.withDatabaseName("test");
+    @Container
+    static MySQLContainer<?> mySQLContainer = new MySQLContainer<>("mysql:8")
+            .withUsername("root")
+            .withPassword("1234")
+            .withDatabaseName("test")
+            .withInitScript("init.sql");
 
-	@Container
-	static GenericContainer<?> redisContainer = new GenericContainer<>("redis:5.0.3-alpine")
-		.withExposedPorts(6379);
+    @Container
+    static GenericContainer<?> redisContainer = new GenericContainer<>("redis:5.0.3-alpine")
+            .withExposedPorts(6379);
 
-	@DynamicPropertySource
-	static void databaseProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.datasource.url", mySQLContainer::getJdbcUrl);
-		registry.add("spring.datasource.username", mySQLContainer::getUsername);
-		registry.add("spring.datasource.password", mySQLContainer::getPassword);
-		registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
-	}
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mySQLContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", mySQLContainer::getUsername);
+        registry.add("spring.datasource.password", mySQLContainer::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+    }
 
-	@DynamicPropertySource
-	static void redisProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.redis.host", redisContainer::getHost);
-		registry.add("spring.redis.port", () -> redisContainer.getFirstMappedPort());
-	}
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", redisContainer::getHost);
+        registry.add("spring.redis.port", () -> redisContainer.getFirstMappedPort());
+    }
 
-	// .env 환경변수 등록
-	@DynamicPropertySource
-	static void dotenvProperties(DynamicPropertyRegistry registry) {
-		Dotenv dotenv = Dotenv.configure()
-			.directory("./../../")
-			.load();
-		dotenv.entries().forEach(entry -> {
-			registry.add(entry.getKey(), entry::getValue);
-		});
-	}
+    // .env 환경변수 등록
+    @DynamicPropertySource
+    static void dotenvProperties(DynamicPropertyRegistry registry) {
+        Dotenv dotenv = Dotenv.configure()
+                .directory("./../../")
+                .load();
+        dotenv.entries().forEach(entry -> {
+            registry.add(entry.getKey(), entry::getValue);
+        });
+    }
 }

--- a/core/infra/src/testFixtures/resources/init.sql
+++ b/core/infra/src/testFixtures/resources/init.sql
@@ -1,0 +1,101 @@
+CREATE
+    DATABASE IF NOT EXISTS test;
+
+USE test;
+
+CREATE TABLE member
+(
+    member_id    bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    auth_id      varchar(255),
+    email        varchar(255) UNIQUE,
+    name         varchar(255),
+    password     varchar(255),
+    phone_number varchar(255) UNIQUE,
+    status       varchar(255),
+    provider     varchar(255),
+    roles        varchar(255),
+    updated_at   datetime(6),
+    updated_by   varchar(255),
+    created_at   datetime(6),
+    created_by   varchar(255)
+);
+
+
+CREATE TABLE store
+(
+    store_id    bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name        varchar(255),
+    description TEXT,
+    location    varchar(255),
+    contact     varchar(255),
+    image       varchar(255),
+    member_id   bigint NOT NULL,
+    updated_at  datetime(6),
+    updated_by  varchar(255),
+    created_at  datetime(6),
+    created_by  varchar(255),
+    start_time  time,
+    end_time    time,
+    FOREIGN KEY (member_id) REFERENCES member (member_id)
+);
+
+CREATE TABLE product
+(
+    product_id     bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name           varchar(255),
+    description    TEXT,
+    price          int,
+    stock_quantity int,
+    thumbnail      varchar(255),
+    store_id       bigint NOT NULL,
+    updated_at     datetime(6),
+    updated_by     varchar(255),
+    created_at     datetime(6),
+    created_by     varchar(255),
+    FOREIGN KEY (store_id) REFERENCES store (store_id)
+);
+
+CREATE TABLE reservation
+(
+    reservation_id   bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    member_id        bigint NOT NULL,
+    store_id         bigint NOT NULL,
+    total_price      int,
+    updated_at       datetime(6),
+    updated_by       varchar(255),
+    created_at       datetime(6),
+    created_by       varchar(255),
+    reservation_time time,
+    FOREIGN KEY (store_id) REFERENCES store (store_id),
+    FOREIGN KEY (member_id) REFERENCES member (member_id)
+);
+
+CREATE TABLE reservation_product
+(
+    reservation_product_id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    quantity               int,
+    reservation_id         bigint NOT NULL,
+    product_id             bigint NOT NULL,
+    updated_at             datetime(6),
+    updated_by             varchar(255),
+    created_at             datetime(6),
+    created_by             varchar(255),
+    FOREIGN KEY (reservation_id) REFERENCES reservation (reservation_id),
+    FOREIGN KEY (product_id) REFERENCES product (product_id)
+);
+
+INSERT INTO member (member_id, auth_id, email, name, password, phone_number, status, provider, roles, updated_at,
+                    updated_by, created_at, created_by)
+VALUES (1, null, 'email@naver.com', '이상민', 'mmsc532mmmm', '010-0000-0000', 'ACTIVE', null, 'ROLE_STORE_OWNER', null,
+        null,
+        null, null);
+
+INSERT INTO store (store_id, name, description, location, contact, image, member_id, updated_at, updated_by, created_at,
+                   created_by, start_time, end_time)
+VALUES (1, 'test', 'test', null, null, null, 1, null, null, null, null, '10:00', '21:00');
+
+INSERT INTO product (product_id, name, description, price, stock_quantity, thumbnail, store_id, updated_at, updated_by,
+                     created_at, created_by)
+VALUES (1, 'test', 'test', 1000, 10, null, 1, null, null, null, null),
+       (2, 'test', 'test', 2000, 10, null, 1, null, null, null, null);
+

--- a/docs/openapi/store-openapi.yaml
+++ b/docs/openapi/store-openapi.yaml
@@ -43,7 +43,8 @@ paths:
             examples:
               make-reservation:
                 value: "{\"storeId\":1,\"orderRequestItems\":[{\"productId\":1,\"\
-                  quantity\":1},{\"productId\":2,\"quantity\":1}]}"
+                  quantity\":1},{\"productId\":2,\"quantity\":1}],\"reservationTime\"\
+                  :\"12:00:00\"}"
       responses:
         "201":
           description: "201"
@@ -138,7 +139,7 @@ paths:
               register-store:
                 value: "{\"name\":\"가게 이름\",\"description\":\"가게 설명\",\"location\"\
                   :\"가게 위치\",\"contact\":[\"010\",\"0000\",\"0000\"],\"image\":\"이\
-                  미지 url\"}"
+                  미지 url\",\"startTime\":\"10:00:00\",\"endTime\":\"21:00:00\"}"
       responses:
         "201":
           description: "201"
@@ -296,6 +297,33 @@ paths:
                     트된 이미지 링크\"}}}"
 components:
   schemas:
+    '[request] make-reservation':
+      title: "[request] make-reservation"
+      required:
+      - reservationTime
+      - storeId
+      type: object
+      properties:
+        orderRequestItems:
+          type: array
+          items:
+            required:
+            - productId
+            - quantity
+            type: object
+            properties:
+              quantity:
+                type: number
+                description: 주문한 수량 값입니다.
+              productId:
+                type: number
+                description: 상품 ID 값입니다.
+        reservationTime:
+          type: string
+          description: 예약 시간입니다. 'HH:mm' 형태입니다.
+        storeId:
+          type: number
+          description: 가게 ID 값입니다.
     '[reqyest] update-product':
       title: "[reqyest] update-product"
       type: object
@@ -383,37 +411,6 @@ components:
         message:
           type: string
           description: 응답 메시지 입니다.
-    '[request] store-register':
-      title: "[request] store-register"
-      required:
-      - description
-      - location
-      - name
-      type: object
-      properties:
-        image:
-          type: string
-          description: 썸네일 이미지 입니다.
-          nullable: true
-        contact:
-          type: array
-          description: 연락처입니다. 문자열 배열로 입력해주세요.
-          nullable: true
-          items:
-            oneOf:
-            - type: object
-            - type: boolean
-            - type: string
-            - type: number
-        name:
-          type: string
-          description: 가게 이름입니다.
-        description:
-          type: string
-          description: 가게 상세 설명입니다.
-        location:
-          type: number
-          description: 가게 위치입니다.
     '[request] product-register':
       title: "[request] product-register"
       required:
@@ -483,6 +480,27 @@ components:
         message:
           type: string
           description: 응답 메시지 입니다.
+    '[response] store-register':
+      title: "[response] store-register"
+      required:
+      - code
+      - message
+      type: object
+      properties:
+        code:
+          type: number
+          description: HttpStatusCode 입니다.
+        data:
+          required:
+          - store_id
+          type: object
+          properties:
+            store_id:
+              type: number
+              description: 생성된 가게 ID 입니다.
+        message:
+          type: string
+          description: 응답 메시지 입니다.
     '[response] make-reservation':
       title: "[response] make-reservation"
       required:
@@ -514,27 +532,45 @@ components:
         message:
           type: string
           description: 응답 메시지 입니다.
-    '[response] store-register':
-      title: "[response] store-register"
+    '[request] store-register':
+      title: "[request] store-register"
       required:
-      - code
-      - message
+      - description
+      - location
+      - name
       type: object
       properties:
-        code:
-          type: number
-          description: HttpStatusCode 입니다.
-        data:
-          required:
-          - store_id
-          type: object
-          properties:
-            store_id:
-              type: number
-              description: 생성된 가게 ID 입니다.
-        message:
+        image:
           type: string
-          description: 응답 메시지 입니다.
+          description: 썸네일 이미지 입니다.
+          nullable: true
+        contact:
+          type: array
+          description: 연락처입니다. 문자열 배열로 입력해주세요.
+          nullable: true
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
+        name:
+          type: string
+          description: 가게 이름입니다.
+        description:
+          type: string
+          description: 가게 상세 설명입니다.
+        startTime:
+          type: string
+          description: 오픈시간입니다. HH:mm 형태
+          nullable: true
+        location:
+          type: number
+          description: 가게 위치입니다.
+        endTime:
+          type: string
+          description: 마감시간입니다. HH:mm 형태
+          nullable: true
     '[response] update-product':
       title: "[response] update-product"
       required:
@@ -600,29 +636,6 @@ components:
         message:
           type: string
           description: 응답 메시지 입니다.
-    '[request] make-reservation':
-      title: "[request] make-reservation"
-      required:
-      - storeId
-      type: object
-      properties:
-        orderRequestItems:
-          type: array
-          items:
-            required:
-            - productId
-            - quantity
-            type: object
-            properties:
-              quantity:
-                type: number
-                description: 주문한 수량 값입니다.
-              productId:
-                type: number
-                description: 상품 ID 값입니다.
-        storeId:
-          type: number
-          description: 가게 ID 값입니다.
     reservations-reservationId486549215:
       type: object
   securitySchemes:

--- a/initdb.d/init.sql
+++ b/initdb.d/init.sql
@@ -1,5 +1,8 @@
-DROP DATABASE IF EXISTS test;
-CREATE DATABASE IF NOT EXISTS test;
+DROP
+    DATABASE IF EXISTS test;
+CREATE
+    DATABASE IF NOT EXISTS test;
+
 USE test;
 
 CREATE TABLE member
@@ -33,6 +36,8 @@ CREATE TABLE store
     updated_by  varchar(255),
     created_at  datetime(6),
     created_by  varchar(255),
+    start_time  time,
+    end_time    time,
     FOREIGN KEY (member_id) REFERENCES member (member_id)
 );
 
@@ -52,40 +57,44 @@ CREATE TABLE product
     FOREIGN KEY (store_id) REFERENCES store (store_id)
 );
 
-CREATE TABLE reservation(
-    reservation_id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    member_id bigint NOT NULL,
-    store_id bigint NOT NULL,
-    total_price int,
-    updated_at     datetime(6),
-    updated_by     varchar(255),
-    created_at     datetime(6),
-    created_by     varchar(255),
+CREATE TABLE reservation
+(
+    reservation_id   bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    member_id        bigint NOT NULL,
+    store_id         bigint NOT NULL,
+    total_price      int,
+    updated_at       datetime(6),
+    updated_by       varchar(255),
+    created_at       datetime(6),
+    created_by       varchar(255),
+    reservation_time time,
     FOREIGN KEY (store_id) REFERENCES store (store_id),
     FOREIGN KEY (member_id) REFERENCES member (member_id)
 );
 
-CREATE TABLE reservation_product(
+CREATE TABLE reservation_product
+(
     reservation_product_id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    quantity int,
-    reservation_id bigint NOT NULL,
-    product_id bigint NOT NULL,
-    updated_at     datetime(6),
-    updated_by     varchar(255),
-    created_at     datetime(6),
-    created_by     varchar(255),
+    quantity               int,
+    reservation_id         bigint NOT NULL,
+    product_id             bigint NOT NULL,
+    updated_at             datetime(6),
+    updated_by             varchar(255),
+    created_at             datetime(6),
+    created_by             varchar(255),
     FOREIGN KEY (reservation_id) REFERENCES reservation (reservation_id),
     FOREIGN KEY (product_id) REFERENCES product (product_id)
 );
 
 INSERT INTO member (member_id, auth_id, email, name, password, phone_number, status, provider, roles, updated_at,
                     updated_by, created_at, created_by)
-VALUES (1, null, 'email@naver.com', '이상민', 'mmsc532mmmm', '010-0000-0000', 'ACTIVE', null, 'ROLE_STORE_OWNER', null, null,
+VALUES (1, null, 'email@naver.com', '이상민', 'mmsc532mmmm', '010-0000-0000', 'ACTIVE', null, 'ROLE_STORE_OWNER', null,
+        null,
         null, null);
 
 INSERT INTO store (store_id, name, description, location, contact, image, member_id, updated_at, updated_by, created_at,
-                   created_by)
-VALUES (1, 'test', 'test', null, null, null, 1, null, null, null,null);
+                   created_by, start_time, end_time)
+VALUES (1, 'test', 'test', null, null, null, 1, null, null, null, null, '10:00', '21:00');
 
 INSERT INTO product (product_id, name, description, price, stock_quantity, thumbnail, store_id, updated_at, updated_by,
                      created_at, created_by)


### PR DESCRIPTION
## 📝 작업 내용
 - 영업 시작/종료 시간, 예약 시간 기능 추가했습니다.
   - 이에 따라 테스트 코드, 문서화를 수정했습니다.
- intellij-java-wooteco-style.xml 를 따랐습니다.
- test용 profile를 분리하고 test containers DB 초기화를 하였습니다.

## 💬 ETC.
- ReservationConcurrencyTest의 경우 mockito를 사용하지 않고 실제 insert 쿼리 문을 사용하는 테스트입니다. 이로 인해 schema.sql와 같이 테스트 DB를 초기화해주는 DDL 스크립트가 필요했습니다. 하지만 sql.init.mode : always를 사용하여 테스트 DB를 초기화하는 schema.sql의 경우에 init.sql와 충돌이 발생하였습니다. 

  - 첫 번째 시도: workflow에 mysql와 schema.sql을 만들고 해당 mysql에 DDL을 실행한 후에 gradle build를 하고자 했습니다.
     - 하지만 이러면 build 결과물에 schema.sql 가 포함되어 결과적으로 동일한 에러를 발생시켰습니다.
     
  - 두 번째 시도: 현재 test containers를 사용하고 있었는데 이를 활용하여 test containers 속 DB에 DDL 스크립트를 적용시키고 ReservationConcurrencyTest 속 쿼리 문을 test containers DB에 날렸습니다.

**부족한 점**
- test containers의 개념이 부족하여 test 코드를 작성할 때 이를 적극적으로 활용하지 못했습니다. 이로 인해 test container DB 초기화 하는 생각을 늦게 했습니다.

### Reference
- https://testcontainers.com/guides/configuration-of-services-running-in-container/

## #️⃣ 연관된 이슈
resolves: #24 #106 