### PR TITLE
별점 순으로 가게 조회하는 API 구현

### DIFF
--- a/api/store/src/main/java/com/backtothefuture/store/controller/StoreController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/StoreController.java
@@ -1,33 +1,52 @@
 package com.backtothefuture.store.controller;
 
-import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.*;
+import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.CREATE;
+import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.SUCCESS;
 
+import com.backtothefuture.domain.response.BfResponse;
+import com.backtothefuture.domain.store.FilteringOption;
+import com.backtothefuture.store.dto.request.StoreRegisterDto;
+import com.backtothefuture.store.dto.response.StoreResponse;
+import com.backtothefuture.store.service.StoreService;
+import jakarta.validation.Valid;
+import java.util.List;
 import java.util.Map;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.backtothefuture.domain.response.BfResponse;
-import com.backtothefuture.store.dto.request.StoreRegisterDto;
-import com.backtothefuture.store.service.StoreService;
-
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/stores")
 public class StoreController {
-	private final StoreService storeService;
+    private final StoreService storeService;
 
-	@PostMapping("")
-	public ResponseEntity<BfResponse<?>> registerStore(
-		@Valid @RequestBody StoreRegisterDto storeRegisterDto) {
-		return ResponseEntity.status(HttpStatus.CREATED)
-			.body(new BfResponse<>(CREATE, Map.of("store_id", storeService.registerStore(storeRegisterDto))));
-	}
+    @PostMapping("")
+    public ResponseEntity<BfResponse<?>> registerStore(
+            @Valid @RequestBody StoreRegisterDto storeRegisterDto) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new BfResponse<>(CREATE, Map.of("store_id", storeService.registerStore(storeRegisterDto))));
+    }
+
+    @GetMapping("")
+    public ResponseEntity<BfResponse<?>> readStores(
+            @RequestParam(defaultValue = "distance") String filteringOption,
+            @RequestParam(defaultValue = "0") Long cursor,
+            @RequestParam(defaultValue = "10") Integer size
+    ) {
+        List<StoreResponse> response = storeService.findStores(
+                FilteringOption.from(filteringOption),
+                cursor,
+                size
+        );
+
+        return ResponseEntity.ok()
+                .body(new BfResponse<>(SUCCESS, response));
+    }
 }

--- a/api/store/src/main/java/com/backtothefuture/store/dto/response/StoreResponse.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/response/StoreResponse.java
@@ -1,0 +1,35 @@
+package com.backtothefuture.store.dto.response;
+
+import com.backtothefuture.domain.store.Store;
+import java.time.LocalTime;
+
+public record StoreResponse(
+        Long id,
+        String name,
+        String image,
+
+        //int surpriseBagAmount,
+        //int surpriseBagPrice,
+        //int surpriseBagDiscountRate, // TODO 서프라이즈백 구분 기능 확정된 후 구현
+
+        double rating,
+        int ratingCount,
+
+        LocalTime startTime,
+        LocalTime endTime
+
+        // TODO 거리 표시
+) {
+
+    public static StoreResponse from(Store store) {
+        return new StoreResponse(
+                store.getId(),
+                store.getName(),
+                store.getImage(),
+                store.getRating(),
+                store.getRatingCount(),
+                store.getStartTime(),
+                store.getEndTime()
+        );
+    }
+}

--- a/api/store/src/main/java/com/backtothefuture/store/service/StoreService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/StoreService.java
@@ -1,64 +1,86 @@
 package com.backtothefuture.store.service;
 
-import static com.backtothefuture.domain.common.enums.GlobalErrorCode.*;
-import static com.backtothefuture.domain.common.enums.StoreErrorCode.*;
+import static com.backtothefuture.domain.common.enums.GlobalErrorCode.CHECK_USER;
+import static com.backtothefuture.domain.common.enums.StoreErrorCode.CHECK_MEMBER;
+import static com.backtothefuture.domain.common.enums.StoreErrorCode.DUPLICATED_STORE_NAME;
 
+import com.backtothefuture.domain.member.Member;
+import com.backtothefuture.domain.member.repository.MemberRepository;
+import com.backtothefuture.domain.store.FilteringOption;
+import com.backtothefuture.domain.store.Store;
+import com.backtothefuture.domain.store.repository.StoreRepository;
+import com.backtothefuture.security.exception.CustomSecurityException;
+import com.backtothefuture.security.service.UserDetailsImpl;
+import com.backtothefuture.store.dto.request.StoreRegisterDto;
+import com.backtothefuture.store.dto.response.StoreResponse;
+import com.backtothefuture.store.exception.StoreException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.backtothefuture.domain.member.Member;
-import com.backtothefuture.domain.member.repository.MemberRepository;
-import com.backtothefuture.domain.store.Store;
-import com.backtothefuture.domain.store.repository.StoreRepository;
-import com.backtothefuture.security.exception.CustomSecurityException;
-import com.backtothefuture.security.service.UserDetailsImpl;
-import com.backtothefuture.store.dto.request.StoreRegisterDto;
-import com.backtothefuture.store.exception.StoreException;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class StoreService {
-	private final MemberRepository memberRepository;
-	private final StoreRepository storeRepository;
+    private final MemberRepository memberRepository;
+    private final StoreRepository storeRepository;
 
-	/**
-	 * 가게 등록
-	 */
-	@Transactional
-	public Long registerStore(StoreRegisterDto storeRegisterDto) {
-		UserDetailsImpl userDetails = (UserDetailsImpl) getUserDetails();
+    /**
+     * 가게 등록
+     */
+    @Transactional
+    public Long registerStore(StoreRegisterDto storeRegisterDto) {
+        UserDetailsImpl userDetails = (UserDetailsImpl) getUserDetails();
 
-		// 회원 조회
-		Member member = memberRepository.findById(userDetails.getId())
-			.orElseThrow(() -> new StoreException(CHECK_MEMBER));
+        // 회원 조회
+        Member member = memberRepository.findById(userDetails.getId())
+                .orElseThrow(() -> new StoreException(CHECK_MEMBER));
 
-		// 가게 중복 체크
-		if(storeRepository.existsByName(storeRegisterDto.name())) {
-			throw new StoreException(DUPLICATED_STORE_NAME);
-		}
+        // 가게 중복 체크
+        if (storeRepository.existsByName(storeRegisterDto.name())) {
+            throw new StoreException(DUPLICATED_STORE_NAME);
+        }
 
-		Store store = StoreRegisterDto.toEntity(storeRegisterDto, member);
-		return storeRepository.save(store).getId();
-	}
+        Store store = StoreRegisterDto.toEntity(storeRegisterDto, member);
+        return storeRepository.save(store).getId();
+    }
 
-	/**
-	 * 인증된 사용자 조회
-	 */
-	private UserDetails getUserDetails() {
-		return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
-			.filter(Authentication::isAuthenticated)
-			.map(Authentication::getPrincipal)
-			.filter(principal -> principal instanceof UserDetails)
-			.map(UserDetailsImpl.class::cast)
-			.orElseThrow(() -> new CustomSecurityException(CHECK_USER));
-	}
+    /**
+     * 인증된 사용자 조회
+     */
+    private UserDetails getUserDetails() {
+        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+                .filter(Authentication::isAuthenticated)
+                .map(Authentication::getPrincipal)
+                .filter(principal -> principal instanceof UserDetails)
+                .map(UserDetailsImpl.class::cast)
+                .orElseThrow(() -> new CustomSecurityException(CHECK_USER));
+    }
+
+    @Transactional(readOnly = true)
+    public List<StoreResponse> findStores(FilteringOption filteringOption, Long cursor, Integer size) {
+        PageRequest pageRequest = PageRequest.of(0, size); // cursor 방식 페이지네이션이기 때문에 pageNumber가 0임
+
+        List<Store> stores = new ArrayList<>();
+
+        switch (filteringOption) {
+            case STAR:
+                    stores = storeRepository.findStoresByCursorOrderByRating(cursor, pageRequest);
+
+            case DISTANCE:
+                    // TODO: 거리순으로 정렬하는 기능
+        }
+
+        return stores.stream()
+                .map(StoreResponse::from)
+                .toList();
+    }
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/review/Review.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/review/Review.java
@@ -1,0 +1,42 @@
+package com.backtothefuture.domain.review;
+
+
+import com.backtothefuture.domain.member.Member;
+import com.backtothefuture.domain.store.Store;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    private int star;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String content;
+}

--- a/core/domain/src/main/java/com/backtothefuture/domain/store/FilteringOption.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/store/FilteringOption.java
@@ -1,0 +1,22 @@
+package com.backtothefuture.domain.store;
+
+import java.util.Arrays;
+
+public enum FilteringOption {
+
+    STAR("star"),
+    DISTANCE("distance");
+
+    private final String text;
+
+    FilteringOption(String text) {
+        this.text = text;
+    }
+
+    public static FilteringOption from(String text) {
+        return Arrays.stream(FilteringOption.values())
+                .filter(filteringOption -> filteringOption.text.equals(text))
+                .findAny()
+                .orElseThrow(); // TODO 예외 처리
+    }
+}

--- a/core/domain/src/main/java/com/backtothefuture/domain/store/Store.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/store/Store.java
@@ -2,7 +2,6 @@ package com.backtothefuture.domain.store;
 
 import com.backtothefuture.domain.common.MutableBaseEntity;
 import com.backtothefuture.domain.member.Member;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,13 +11,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -47,6 +45,10 @@ public class Store extends MutableBaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;        // 회원
+
+    private double rating; // TODO 리뷰가 등록될 때 rating, ratingCount가 업데이트되어야 함
+
+    private int ratingCount;
 
     private LocalTime startTime; // 영업 시작 시간
 

--- a/core/domain/src/main/java/com/backtothefuture/domain/store/repository/StoreRepository.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/store/repository/StoreRepository.java
@@ -1,13 +1,24 @@
 package com.backtothefuture.domain.store.repository;
 
 import com.backtothefuture.domain.store.Store;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
-	Optional<Store> findById(Long id);
+    Optional<Store> findById(Long id);
 
-	boolean existsByName(String name);
+    @Query("SELECT store FROM Store store "
+            + "WHERE (:cursor = 0L OR store.id < :cursor) "
+            + "ORDER BY store.rating DESC")
+    List<Store> findStoresByCursorOrderByRating(
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+
+    boolean existsByName(String name);
 }

--- a/core/infra/src/testFixtures/resources/init.sql
+++ b/core/infra/src/testFixtures/resources/init.sql
@@ -84,6 +84,14 @@ CREATE TABLE reservation_product
     FOREIGN KEY (product_id) REFERENCES product (product_id)
 );
 
+CREATE TABLE IF NOT EXISTS review (
+    review_id       VARCHAR(255)    NOT NULL,
+    member_id       VARCHAR(255)    NOT NULL,
+    store_id        VARCHAR(255)    NOT NULL,
+    star            VARCHAR(255)    NULL,
+    content         VARCHAR(255)    NULL
+);
+
 INSERT INTO member (member_id, auth_id, email, name, password, phone_number, status, provider, roles, updated_at,
                     updated_by, created_at, created_by)
 VALUES (1, null, 'email@naver.com', '이상민', 'mmsc532mmmm', '010-0000-0000', 'ACTIVE', null, 'ROLE_STORE_OWNER', null,

--- a/core/infra/src/testFixtures/resources/init.sql
+++ b/core/infra/src/testFixtures/resources/init.sql
@@ -23,20 +23,22 @@ CREATE TABLE member
 
 CREATE TABLE store
 (
-    store_id    bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    name        varchar(255),
-    description TEXT,
-    location    varchar(255),
-    contact     varchar(255),
-    image       varchar(255),
-    member_id   bigint NOT NULL,
-    updated_at  datetime(6),
-    updated_by  varchar(255),
-    created_at  datetime(6),
-    created_by  varchar(255),
-    start_time  time,
-    end_time    time,
-    FOREIGN KEY (member_id) REFERENCES member (member_id)
+    store_id     bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name         varchar(255),
+    description  TEXT,
+    location     varchar(255),
+    contact      varchar(255),
+    image        varchar(255),
+    member_id    bigint NOT NULL,
+    updated_at   datetime(6),
+    updated_by   varchar(255),
+    created_at   datetime(6),
+    created_by   varchar(255),
+    rating       double,
+    rating_count int,
+    start_time   time,
+    end_time     time,
+    FOREIGN KEY  (member_id) REFERENCES member (member_id)
 );
 
 CREATE TABLE product


### PR DESCRIPTION
## 📝 작업 내용
 - 별점 순으로 가게 조회하는 API 구현했습니다.

## 💬 ETC.
 - cursor, size 관련해서는 프론트랑 논의해야 할 것 같아서 이번주에 슬랙으로 논의하고 변경되면 수정하겠습니다.
 - 가게 정보 표시할 때 서프라이즈백 기준으로 가격/재고/할인율을 표시해줘야 하는데 현재 `product`에 구분 가능한 내용이 없고 관련된 기획도 없어서 구현하지 못했습니다.
  - 정해지면 구현하도록 하겠습니다.
- 가게 정보 표시할 때 리뷰 평균 평점이랑 리뷰 개수를 보여줘야 하는데, 가게 조회 시 count/average 쿼리로 매번 조회하는 것보다는 리뷰가 등록되면 가게 정보를 업데이트 하는게 성능적으로 나을 것으로 판단하여 후자 케이스로 구현하였습니다. 관련하여 의견 주시면 감사하겠습니다.

## #️⃣ 연관된 이슈
resolves: #92 