### PR TITLE
feat: 이메일 인증방식 변경 #117

### DIFF
--- a/api/event/src/main/java/com/backtothefuture/event/controller/CertificateController.java
+++ b/api/event/src/main/java/com/backtothefuture/event/controller/CertificateController.java
@@ -1,27 +1,22 @@
 package com.backtothefuture.event.controller;
 
+import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.SUCCESS;
+
 import com.backtothefuture.domain.response.BfResponse;
 import com.backtothefuture.event.dto.request.MailCertificateRequestDto;
-import com.backtothefuture.event.dto.request.VerifyCertificateRequestDto;
+import com.backtothefuture.event.dto.response.CertificateMailResponseDto;
 import com.backtothefuture.event.service.CertificateService;
 import jakarta.validation.Valid;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.ModelAndView;
-
-import java.util.Map;
-
-import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.CREATE;
-import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.SUCCESS;
 
 @RestController
 @RequiredArgsConstructor
@@ -47,30 +42,23 @@ public class CertificateController {
 //    }
 
     @PostMapping("/email")
-    public ResponseEntity<BfResponse<?>> sendCertificateMail(
+    public ResponseEntity<BfResponse<CertificateMailResponseDto>> sendCertificateMail(
             @Valid @RequestBody MailCertificateRequestDto mailCertificateRequestDto
     ) {
-        int mailExp = certificationService.sendEmailCertificateNumber(mailCertificateRequestDto);
+        CertificateMailResponseDto responseDto = certificationService.sendEmailCertificateNumber(
+                mailCertificateRequestDto);
 
         return ResponseEntity.ok()
-                .body(new BfResponse<>(SUCCESS, Map.of("mail_expiration_seconds", mailExp)));
+                .body(new BfResponse<>(SUCCESS, responseDto));
     }
 
-    // TODO: html 버튼, form 전송으로 변경할것
     @GetMapping("/email")
-    public ModelAndView verifyCertificateMail(
+    public ResponseEntity<BfResponse<?>> verifyMailCertificationNumber(
             @RequestParam String email,
             @RequestParam String certificationNumber
     ) {
-        certificationService.verifyCertificateEmailNumber(email, certificationNumber);
-        // 인증 성공 시 성공 페이지를 반환
-        ModelAndView successModelAndView = new ModelAndView("mail/verify-success");
-        return successModelAndView;
-    }
-
-    @GetMapping("/email/{email}/status")
-    public ResponseEntity<BfResponse<?>> checkCertificateEmailStatus(@PathVariable String email) {
+        boolean isValid = certificationService.verifyCertificateEmailNumber(email, certificationNumber);
         return ResponseEntity.ok()
-                .body(new BfResponse<>(SUCCESS, Map.of("is_certificated", certificationService.getCertificateEmailStatus(email))));
+                .body(new BfResponse<>(SUCCESS, Map.of("isValid", isValid)));
     }
 }

--- a/api/event/src/main/java/com/backtothefuture/event/controller/CertificateController.java
+++ b/api/event/src/main/java/com/backtothefuture/event/controller/CertificateController.java
@@ -3,13 +3,24 @@ package com.backtothefuture.event.controller;
 import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.SUCCESS;
 
 import com.backtothefuture.domain.response.BfResponse;
+import com.backtothefuture.domain.response.ErrorResponse;
 import com.backtothefuture.event.dto.request.MailCertificateRequestDto;
 import com.backtothefuture.event.dto.response.CertificateMailResponseDto;
 import com.backtothefuture.event.service.CertificateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "certificate", description = "인증 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/certificate")
@@ -41,7 +53,20 @@ public class CertificateController {
 //        return ResponseEntity.ok(new BfResponse<>(null));
 //    }
 
-    @PostMapping("/email")
+    @Operation(summary = "인증코드 메일 전송 API", description = "이메일로 인증코드를 전송합니다.")
+    @SecurityRequirements(value = {}) // no security
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증 번호 발송 성공", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "400", description = "이메일 형식에 맞지 않습니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "invalid email", value = "{\"errorCode\": 400, \"errorMessage\": \"입력값에 대한 검증에 실패했습니다.\", \"validation\": {\"email\": \"이메일 형식에 맞지 않습니다.\"}}")
+                            }
+                    ))
+    })
+    @PostMapping(value = "/email", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<BfResponse<CertificateMailResponseDto>> sendCertificateMail(
             @Valid @RequestBody MailCertificateRequestDto mailCertificateRequestDto
     ) {
@@ -52,10 +77,23 @@ public class CertificateController {
                 .body(new BfResponse<>(SUCCESS, responseDto));
     }
 
-    @GetMapping("/email")
+    @Operation(summary = "이메일 인증 번호 검증 API", description = "이메일과 인증 번호를 사용하여 인증 번호의 유효성을 검증합니다.")
+    @SecurityRequirements(value = {}) // no security
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증 번호 유효성 검사 결과", useReturnTypeSchema = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "valid certification number", value = "{\"code\": 200, \"message\": \"정상 처리되었습니다.\", \"data\": {\"isValid\": true}}"),
+                                    @ExampleObject(name = "invalid certification number", value = "{\"code\": 200, \"message\": \"정상 처리되었습니다.\", \"data\": {\"isValid\": false}}")
+                            }
+                    )
+            )
+    })
+    @GetMapping(value = "/email", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<BfResponse<?>> verifyMailCertificationNumber(
-            @RequestParam String email,
-            @RequestParam String certificationNumber
+            @Parameter(description = "이메일 주소", required = true) @RequestParam String email,
+            @Parameter(description = "인증 번호", required = true) @RequestParam String certificationNumber
     ) {
         boolean isValid = certificationService.verifyCertificateEmailNumber(email, certificationNumber);
         return ResponseEntity.ok()

--- a/api/event/src/main/java/com/backtothefuture/event/dto/request/MailCertificateRequestDto.java
+++ b/api/event/src/main/java/com/backtothefuture/event/dto/request/MailCertificateRequestDto.java
@@ -1,10 +1,12 @@
 package com.backtothefuture.event.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 
 public record MailCertificateRequestDto(
 
+        @Schema(description = "사용자 이메일 주소", example = "user@example.com", required = true)
         @NotEmpty(message = "이메일 입력은 필수 입니다.")
         @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")
         String email

--- a/api/event/src/main/java/com/backtothefuture/event/dto/response/CertificateMailResponseDto.java
+++ b/api/event/src/main/java/com/backtothefuture/event/dto/response/CertificateMailResponseDto.java
@@ -1,0 +1,10 @@
+package com.backtothefuture.event.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CertificateMailResponseDto(
+        int mailExpirationSeconds,
+        String certificationNumber
+) {
+}

--- a/api/event/src/main/java/com/backtothefuture/event/dto/response/CertificateMailResponseDto.java
+++ b/api/event/src/main/java/com/backtothefuture/event/dto/response/CertificateMailResponseDto.java
@@ -1,10 +1,14 @@
 package com.backtothefuture.event.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record CertificateMailResponseDto(
+        @Schema(description = "인증 번호 유효 시간(초)", example = "600")
         int mailExpirationSeconds,
+
+        @Schema(description = "인증 번호", example = "123456")
         String certificationNumber
 ) {
 }

--- a/api/event/src/main/java/com/backtothefuture/event/service/CertificateService.java
+++ b/api/event/src/main/java/com/backtothefuture/event/service/CertificateService.java
@@ -6,7 +6,6 @@ import com.backtothefuture.domain.common.util.RandomNumUtil;
 import com.backtothefuture.event.dto.request.MailCertificateRequestDto;
 import com.backtothefuture.event.dto.response.CertificateMailResponseDto;
 import com.backtothefuture.event.exception.CertificateException;
-import com.backtothefuture.event.exception.VerifyMailFailException;
 import jakarta.mail.MessagingException;
 import java.util.HashMap;
 import lombok.RequiredArgsConstructor;

--- a/api/event/src/main/resources/application.yml
+++ b/api/event/src/main/resources/application.yml
@@ -10,12 +10,10 @@ spring:
         format_sql: true # console 창에 보여줄때 format 여부
 
   certification:
-    #    coolsms:
-    #      fromPhoneNumber: ${COOL_SMS_FROM_PHONE_NUMBER}
-    #      api: ${COOL_SMS_API_KEY}
-    #      secret: ${COOL_SMS_API_SECRET_KEY}
-    mail:
-      baseurl: "http://localhost:8084/v1"
+  #    coolsms:
+  #      fromPhoneNumber: ${COOL_SMS_FROM_PHONE_NUMBER}
+  #      api: ${COOL_SMS_API_KEY}
+  #      secret: ${COOL_SMS_API_SECRET_KEY}
   mail:
     host: smtp.gmail.com
     port: 587

--- a/api/event/src/test/java/com/backtothefuture/event/EventApplicationTests.java
+++ b/api/event/src/test/java/com/backtothefuture/event/EventApplicationTests.java
@@ -127,33 +127,5 @@ class EventApplicationTests extends BfTestConfig {
 //                        )));
 //    }
 
-    @Test
-    @DisplayName("인증 메일 전송 테스트")
-    void sendCertificateMailTest() throws Exception {
-        MailCertificateRequestDto requestDto = new MailCertificateRequestDto("test@example.com");
-        when(certificateService.sendEmailCertificateNumber(any(MailCertificateRequestDto.class))).thenReturn(600);
-
-        this.mockMvc.perform(post("/certificate/email")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestDto)))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("인증 메일 검증 테스트")
-    void verifyCertificateMailTest() throws Exception {
-        this.mockMvc.perform(get("/certificate/email")
-                        .param("email", "test@example.com")
-                        .param("certificationNumber", "123456"))
-                .andExpect(view().name("mail/verify-success"));
-    }
-
-    @Test
-    @DisplayName("이메일 인증 상태 확인 테스트")
-    void checkCertificateEmailStatusTest() throws Exception {
-        when(certificateService.getCertificateEmailStatus("test@example.com")).thenReturn(true);
-
-        this.mockMvc.perform(get("/certificate/email/{email}/status", "test@example.com"))
-                .andExpect(status().isOk());
-    }
+// TODO: 메일 전송/검증 API 테스트 작성
 }

--- a/core/domain/build.gradle
+++ b/core/domain/build.gradle
@@ -11,4 +11,6 @@ dependencies {
     // aws s3
     implementation platform('software.amazon.awssdk:bom:2.21.1')
     implementation 'software.amazon.awssdk:s3'
+    // springdoc
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/repository/RedisRepository.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/repository/RedisRepository.java
@@ -14,134 +14,146 @@ import lombok.RequiredArgsConstructor;
 @Repository
 @RequiredArgsConstructor
 public class RedisRepository {
-	@Value("${jwt.refresh-expiration-seconds}")
-	private int refreshExp;
+    @Value("${jwt.refresh-expiration-seconds}")
+    private int refreshExp;
 
-	@Value("${certification.message.expiration-seconds}")
-	private int messageExp;
+    @Value("${certification.message.expiration-seconds}")
+    private int messageExp;
 
-	@Value("${certification.mail.expiration-seconds}")
-	private int mailExp;
+    @Value("${certification.mail.expiration-seconds}")
+    private int mailExp;
 
-	private final RedisTemplate<String, Object> redisTemplate;
+    @Value("${certification.mail.redis-key-prefix}")
+    String mailKeyPrefix;
 
-	/**
-	 * refresh token 저장
-	 */
-	public void saveToken(Long memberId, String refreshToken) {
-		ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
-		Duration expireDuration = Duration.ofSeconds(refreshExp);
-		valueOperations.set(String.valueOf(memberId), Map.of("refreshToken", refreshToken), expireDuration);
-	}
+    private final RedisTemplate<String, Object> redisTemplate;
 
-	/**
-	 * refresh token 삭제
-	 */
-	public void deleteRefreshToken(Long memberId) {
-		redisTemplate.delete(String.valueOf(memberId));
-	}
+    /**
+     * refresh token 저장
+     */
+    public void saveToken(Long memberId, String refreshToken) {
+        ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(refreshExp);
+        valueOperations.set(String.valueOf(memberId), Map.of("refreshToken", refreshToken), expireDuration);
+    }
 
-	/**
-	 * refresh token 가져 오기
-	 */
-	public Map getRefreshToken(Long memberId) {
-		return (Map) redisTemplate.opsForValue().get(String.valueOf(memberId));
-	}
+    /**
+     * refresh token 삭제
+     */
+    public void deleteRefreshToken(Long memberId) {
+        redisTemplate.delete(String.valueOf(memberId));
+    }
 
-	/**
-	 * refresh token 존재 여부 확인
-	 */
-	public Boolean hasKey(Long memberId){
-		return redisTemplate.hasKey(String.valueOf(memberId));
-	}
+    /**
+     * refresh token 가져 오기
+     */
+    public Map getRefreshToken(Long memberId) {
+        return (Map) redisTemplate.opsForValue().get(String.valueOf(memberId));
+    }
 
-	/**
-	 * 인증 번호 저장
-	 */
-	public void saveCertificationNumber(String phoneNumber, String certificationNumber) {
-		ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
-		Duration expireDuration = Duration.ofSeconds(refreshExp);
-		valueOperations.set(phoneNumber, certificationNumber, expireDuration);
-	}
+    /**
+     * refresh token 존재 여부 확인
+     */
+    public Boolean hasKey(Long memberId) {
+        return redisTemplate.hasKey(String.valueOf(memberId));
+    }
 
-	/**
-	 * 이메일 인증 번호 저장
-	 */
-	public void saveCertificationEmailNumber(String email, String certificationNumber) {
-		ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
-		Duration expireDuration = Duration.ofSeconds(mailExp);
-		valueOperations.set(email, certificationNumber, expireDuration);
-	}
+    /**
+     * 인증 번호 저장
+     */
+    public void saveCertificationNumber(String phoneNumber, String certificationNumber) {
+        ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(refreshExp);
+        valueOperations.set(phoneNumber, certificationNumber, expireDuration);
+    }
 
-	/**
-	 * 이메일 인증 유효시간 반환
-	 */
-	public int getMailExp() {
-		return mailExp;
-	}
+    /**
+     * 이메일 인증 번호 저장 형식 - "email-certificate-{email}" : {certificationNumber}
+     */
+    public void saveCertificationEmailNumber(String email, String certificationNumber) {
+        ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(mailExp);
+        valueOperations.set(mailKeyPrefix + email, certificationNumber, expireDuration);
+    }
 
-	/**
-	 * 비트 값을 설정하고 만료 시간을 지정
-	 *
-	 * @param key    Redis 키
-	 * @param offset 비트 위치
-	 * @param value  설정할 비트 값
-	 * @param ttl    만료 시간 (초 단위)
-	 */
-	protected void setBitWithExpiration(String key, long offset, boolean value, int ttl) {
-		redisTemplate.opsForValue().setBit(key, offset, value);
-		redisTemplate.expire(key, ttl, TimeUnit.SECONDS);
-	}
+    /**
+     * 이메일 인증 유효시간 반환
+     */
+    public int getMailExp() {
+        return mailExp;
+    }
 
-	/**
-	 * 비트 값 조회
-	 *
-	 * @param key    Redis 키
-	 * @param offset 비트 위치
-	 * @return 비트 값 (boolean)
-	 */
-	protected boolean getBit(String key, long offset) {
-		Boolean value = redisTemplate.opsForValue().getBit(key, offset);
-		return value != null && value;
-	}
+    /**
+     * 비트 값을 설정하고 만료 시간을 지정
+     *
+     * @param key    Redis 키
+     * @param offset 비트 위치
+     * @param value  설정할 비트 값
+     * @param ttl    만료 시간 (초 단위)
+     */
+    protected void setBitWithExpiration(String key, long offset, boolean value, int ttl) {
+        redisTemplate.opsForValue().setBit(key, offset, value);
+        redisTemplate.expire(key, ttl, TimeUnit.SECONDS);
+    }
 
-	public void setMailCertificationFlag(String email) {
-		String mailCertificatedKey = getMailCertificationKey(email);
-		setBitWithExpiration(mailCertificatedKey, 0, true, mailExp);
-	}
+    /**
+     * 비트 값 조회
+     *
+     * @param key    Redis 키
+     * @param offset 비트 위치
+     * @return 비트 값 (boolean)
+     */
+    protected boolean getBit(String key, long offset) {
+        Boolean value = redisTemplate.opsForValue().getBit(key, offset);
+        return value != null && value;
+    }
 
-	public Boolean getMailCertificationFlag(String email) {
-		String mailCertificatedKey = getMailCertificationKey(email);
-		return getBit(mailCertificatedKey, 0);
-	}
+    public Boolean getMailCertificationFlag(String email) {
+        String mailCertificatedKey = getMailCertificationKey(email);
+        return getBit(mailCertificatedKey, 0);
+    }
 
-	public void deleteMailCertificationFlag(String email) {
-		String mailCertificatedKey = getMailCertificationKey(email);
-		redisTemplate.delete(mailCertificatedKey);
-	}
+    public void deleteMailCertificationFlag(String email) {
+        String mailCertificatedKey = getMailCertificationKey(email);
+        redisTemplate.delete(mailCertificatedKey);
+    }
 
-	protected String getMailCertificationKey(String email) {
-		return "email" + ":" + email + "verifyFlag";
-	}
+    protected String getMailCertificationKey(String email) {
+        return "email" + ":" + email + "verifyFlag";
+    }
 
-	/**
-	 * 인증 번호 가져 오기
-	 */
-	public String getCertificationNumber(String phoneNumber) {
-		return (String) redisTemplate.opsForValue().get(phoneNumber);
-	}
+    /**
+     * 인증 번호 가져 오기
+     */
+    public String getCertificationNumber(String phoneNumber) {
+        return (String) redisTemplate.opsForValue().get(phoneNumber);
+    }
 
-	/**
-	 * 인증 번호 존재 조회
-	 */
-	public Boolean hasKey(String key){
-		return redisTemplate.hasKey(key);
-	}
+    /**
+     * 인증 번호 가져 오기
+     */
+    public String getCertificationEmailNumber(String email) {
+        return (String) redisTemplate.opsForValue().get(mailKeyPrefix + email);
+    }
 
-	/**
-	 * 인증 번호 삭제
-	 */
-	public void deleteCertificationNumber(String phoneNumber) {
-		redisTemplate.delete(phoneNumber);
-	}
+    /**
+     * 인증 번호 존재 조회
+     */
+    public Boolean hasKey(String key) {
+        return redisTemplate.hasKey(key);
+    }
+
+    /**
+     * 인증 번호 존재 조회
+     */
+    public Boolean hashEmailKey(String email) {
+        return redisTemplate.hasKey(mailKeyPrefix + email);
+    }
+
+    /**
+     * 인증 번호 삭제
+     */
+    public void deleteCertificationNumber(String phoneNumber) {
+        redisTemplate.delete(phoneNumber);
+    }
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/response/BfResponse.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/response/BfResponse.java
@@ -5,24 +5,30 @@ import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.*;
 import com.backtothefuture.domain.common.enums.GlobalSuccessCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 public class BfResponse<T> {
-	private int code;
-	private String message;
-	private T data;
+    @Schema(description = "응답 코드", example = "200")
+    private int code;
 
-	public BfResponse(T data) {
-		this.code = SUCCESS.getCode();
-		this.message = SUCCESS.getMessage();
-		this.data = data;
-	}
+    @Schema(description = "응답 메시지", example = "성공")
+    private String message;
 
-	public BfResponse(GlobalSuccessCode statusCode, T data) {
-		this.code = statusCode.getCode();
-		this.message = statusCode.getMessage();
-		this.data = data;
-	}
+    @Schema(description = "응답 데이터")
+    private T data;
+
+    public BfResponse(T data) {
+        this.code = SUCCESS.getCode();
+        this.message = SUCCESS.getMessage();
+        this.data = data;
+    }
+
+    public BfResponse(GlobalSuccessCode statusCode, T data) {
+        this.code = statusCode.getCode();
+        this.message = statusCode.getMessage();
+        this.data = data;
+    }
 }

--- a/core/domain/src/main/resources/application-domain.yml
+++ b/core/domain/src/main/resources/application-domain.yml
@@ -4,6 +4,7 @@ jwt:
 certification:
   mail:
     expiration-seconds: 600 # 이메일 인증 만료 시간
+    redis-key-prefix: email-certificate-
   message:
     expiration-seconds: 180 # 인증 만료시간
 

--- a/docs/openapi/event-openapi.yaml
+++ b/docs/openapi/event-openapi.yaml
@@ -1,234 +1,146 @@
 openapi: 3.0.1
 info:
-  title: Bag To the Future
-  description: API Documentation
-  version: 0.1.0
+  title: 백투더퓨처 API Documentation
+  description: 백투더퓨처 API 문서입니다.
+  version: v1.0.0
 servers:
 - url: http://localhost:8084/v1
-tags: []
+  description: Generated server url
+security:
+- Authorization: []
+tags:
+- name: certificate
+  description: 인증 API
 paths:
   /certificate/email:
     get:
       tags:
       - certificate
-      summary: 인증 메일 검증
-      description: "인증 메일 검증 API입니다. 메일 수신자가 링크를 클릭하고, 이 API를 통해 인증하게 됩니다."
-      operationId: verify-certificate-email
-      responses:
-        "200":
-          description: "200"
-          content:
-            text/html;charset=UTF-8:
-              schema:
-                $ref: '#/components/schemas/certificate-email486549215'
-              examples:
-                verify-certificate-email:
-                  value: |-
-                    <!DOCTYPE html>
-                    <html>
-                    <head>
-                        <title>인증 결과</title>
-                        <meta charset="utf-8">
-                    </head>
-                        <h1>성공적으로 인증되었습니다. 앱 화면으로 돌아가 주세요.</h1>
-                    </html>
-    post:
-      tags:
-      - certificate
-      summary: 인증 메일 전송 API
-      description: 인증 메일 전송 API 입니다.
-      operationId: send-certificate-email
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/certificate-email486549215'
-            examples:
-              send-certificate-email:
-                value: "{\"email\":\"test@example.com\"}"
-      responses:
-        "200":
-          description: "200"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/[response] send-certificate-email"
-              examples:
-                send-certificate-email:
-                  value: "{\"code\":200,\"message\":\"정상 처리되었습니다.\",\"data\":{\"mail_expiration_seconds\"\
-                    :600}}"
-  /certificate/message:
-    post:
-      tags:
-      - certificate
-      summary: 인증 번호 검증 API
-      description: 인증 번호 검증 API입니다.
-      operationId: verify-certificate-number
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/[request] verify-certificate-number"
-            examples:
-              verify-certificate-number:
-                value: "{\"phoneNumber\":[\"010\",\"1234\",\"5678\"],\"certificationNumber\"\
-                  :\"418790\"}"
-      responses:
-        "200":
-          description: "200"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/[response] verify-certificate-number"
-              examples:
-                verify-certificate-number:
-                  value: "{\"code\":200,\"message\":\"정상 처리되었습니다.\"}"
-  /certificate/message/{phoneNumber}:
-    post:
-      tags:
-      - certificate
-      summary: 인증 번호 발급 API
-      description: 인증 번호 발급 API입니다.
-      operationId: get-certificate-number
-      parameters:
-      - name: phoneNumber
-        in: path
-        description: ""
-        required: true
-        schema:
-          type: string
-      responses:
-        "201":
-          description: "201"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/[response] get-certificate-number"
-              examples:
-                get-certificate-number:
-                  value: "{\"code\":201,\"message\":\"정상적으로 생성되었습니다.\",\"data\":{\"\
-                    certification_number\":\"374645\"}}"
-  /certificate/email/{email}/status:
-    get:
-      tags:
-      - certificate
-      summary: 이메일 인증 상태 확인
-      description: 이메일 인증 상태 확인 API입니다.
-      operationId: check-certificate-email-status
+      summary: 이메일 인증 번호 검증 API
+      description: 이메일과 인증 번호를 사용하여 인증 번호의 유효성을 검증합니다.
+      operationId: verifyMailCertificationNumber
       parameters:
       - name: email
-        in: path
-        description: ""
+        in: query
+        description: 이메일 주소
+        required: true
+        schema:
+          type: string
+      - name: certificationNumber
+        in: query
+        description: 인증 번호
         required: true
         schema:
           type: string
       responses:
         "200":
-          description: "200"
+          description: 인증 번호 유효성 검사 결과
+          content:
+            application/json:
+              examples:
+                valid certification number:
+                  description: valid certification number
+                  value:
+                    code: 200
+                    message: 정상 처리되었습니다.
+                    data:
+                      isValid: true
+                invalid certification number:
+                  description: invalid certification number
+                  value:
+                    code: 200
+                    message: 정상 처리되었습니다.
+                    data:
+                      isValid: false
+      security: []
+    post:
+      tags:
+      - certificate
+      summary: 인증코드 메일 전송 API
+      description: 이메일로 인증코드를 전송합니다.
+      operationId: sendCertificateMail
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MailCertificateRequestDto'
+        required: true
+      responses:
+        "400":
+          description: 이메일 형식에 맞지 않습니다.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/[response] check-certificate-email-status"
+                $ref: '#/components/schemas/ErrorResponse'
               examples:
-                check-certificate-email-status:
-                  value: "{\"code\":200,\"message\":\"정상 처리되었습니다.\",\"data\":{\"is_certificated\"\
-                    :true}}"
+                invalid email:
+                  description: invalid email
+                  value:
+                    errorCode: 400
+                    errorMessage: 입력값에 대한 검증에 실패했습니다.
+                    validation:
+                      email: 이메일 형식에 맞지 않습니다.
+        "200":
+          description: 인증 번호 발송 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BfResponseCertificateMailResponseDto'
+      security: []
 components:
   schemas:
-    '[response] send-certificate-email':
-      title: "[response] send-certificate-email"
+    MailCertificateRequestDto:
       required:
-      - code
-      - message
+      - email
       type: object
       properties:
-        code:
-          type: number
-          description: 응답 코드
-        data:
-          required:
-          - mail_expiration_seconds
+        email:
+          pattern: "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$"
+          type: string
+          description: 사용자 이메일 주소
+          example: user@example.com
+    ErrorResponse:
+      type: object
+      properties:
+        errorCode:
+          type: integer
+          format: int32
+        errorMessage:
+          type: string
+        validation:
           type: object
-          properties:
-            mail_expiration_seconds:
-              type: number
-              description: 인증 만료 시간(초)
-        message:
-          type: string
-          description: 응답 메시지
-    '[response] check-certificate-email-status':
-      title: "[response] check-certificate-email-status"
-      required:
-      - code
-      - message
+          additionalProperties:
+            type: string
+    BfResponseCertificateMailResponseDto:
       type: object
       properties:
         code:
-          type: number
+          type: integer
           description: 응답 코드
+          format: int32
+          example: 200
+        message:
+          type: string
+          description: 응답 메시지
+          example: 성공
         data:
-          required:
-          - is_certificated
-          type: object
-          properties:
-            is_certificated:
-              type: boolean
-              description: "인증 여부. true: 인증 / false: 미인증"
-        message:
-          type: string
-          description: 응답 메시지
-    '[response] get-certificate-number':
-      title: "[response] get-certificate-number"
-      required:
-      - code
-      - message
+          $ref: '#/components/schemas/CertificateMailResponseDto'
+    CertificateMailResponseDto:
       type: object
       properties:
-        code:
-          type: number
-          description: 응답 코드
-        data:
-          required:
-          - certification_number
-          type: object
-          properties:
-            certification_number:
-              type: string
-              description: 인증 번호
-        message:
-          type: string
-          description: 응답 메시지
-    '[response] verify-certificate-number':
-      title: "[response] verify-certificate-number"
-      required:
-      - code
-      - message
-      type: object
-      properties:
-        code:
-          type: number
-          description: 응답 코드
-        message:
-          type: string
-          description: 응답 메시지
-    certificate-email486549215:
-      type: object
-    '[request] verify-certificate-number':
-      title: "[request] verify-certificate-number"
-      required:
-      - certificationNumber
-      - phoneNumber
-      type: object
-      properties:
-        phoneNumber:
-          type: array
-          description: 전화번호
-          items:
-            oneOf:
-            - type: object
-            - type: boolean
-            - type: string
-            - type: number
+        mailExpirationSeconds:
+          type: integer
+          description: 인증 번호 유효 시간(초)
+          format: int32
+          example: 600
         certificationNumber:
           type: string
-          description: 인증번호
+          description: 인증 번호
+          example: "123456"
+      description: 응답 데이터
+  securitySchemes:
+    Authorization:
+      type: http
+      name: Authorization
+      scheme: bearer
+      bearerFormat: JWT


### PR DESCRIPTION
## 📝 작업 내용
- 이메일 인증메일 전송 -> 메일 본문의 링크 클릭 -> 인증 방식에서
- 이메일 인증메일 전송 -> 메일 본문의 인증코드 프론트 화면에 입력 -> 검증 방식으로 변경
- swagger 문서화

## 💬 ETC.
### gerneric type의 response schema 정의
**1. `ResponseEntity<BfResponse<CertificateMailResponseDto>>` 처럼 dto 정의할 경우**
```
useReturnTypeSchema = true
```
옵션으로 문서화 가능합니다.
<img width="613" alt="image" src="https://github.com/backtothefuture-team/backtothefuture-backend/assets/67352902/c0a661c4-c1aa-4d61-9fc9-8bf55c6222d0">


**2. `Map.of(..)`로 응답할 경우**
이때 문서화 방법은 찾지 못했습니다.
다만 이렇게 응답하는 경우 data 에 대한 필드가 하나인 경우가 대부분이라,
example을 정의하는것으로 대체해도 괜찮을 것 같다는 생각이 듭니다.
<img width="639" alt="image" src="https://github.com/backtothefuture-team/backtothefuture-backend/assets/67352902/bcf18df1-d4e2-4a47-8d0c-5beceb8f31a5">


## #️⃣ 연관된 이슈
resolves: #117 