### PR TITLE
store, product API 문서화, octet-stream 컨버터 추가

### DIFF
--- a/api/store/src/main/java/com/backtothefuture/store/controller/ProductController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/ProductController.java
@@ -7,6 +7,8 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 import com.backtothefuture.domain.response.BfResponse;
 import com.backtothefuture.store.dto.request.ProductRegisterDto;
 import com.backtothefuture.store.dto.request.ProductUpdateDto;
+import com.backtothefuture.store.dto.response.ProductGetOneResponseDto;
+import com.backtothefuture.store.dto.response.ProductResponseDto;
 import com.backtothefuture.store.service.ProductService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -64,13 +66,18 @@ public class ProductController {
     }
 
     // 상품 단건 조회 API
+    @Operation(summary = "상품 정보 조회", description = "특정 가게의 특정 상품에 대한 자세한 정보를 조회합니다.",
+            parameters = {
+                    @Parameter(name = "storeId", description = "가게 ID", required = true),
+                    @Parameter(name = "productId", description = "상품 ID", required = true)
+            })
     @GetMapping("/stores/{storeId}/products/{productId}")
-    public ResponseEntity<BfResponse<?>> getProduct(
+    public ResponseEntity<BfResponse<ProductGetOneResponseDto>> getProduct(
             @PathVariable Long storeId,
             @PathVariable Long productId
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(new BfResponse<>(SUCCESS, Map.of("product", productService.getProduct(storeId, productId))));
+                .body(new BfResponse<>(SUCCESS, productService.getProduct(storeId, productId)));
     }
 
     // 모든 상품 조회 API
@@ -84,7 +91,7 @@ public class ProductController {
     // 상품 수정 API
     // TODO: ROLE 을 STORE_OWNER, ADMIN 제한
     @PatchMapping("/stores/{storeId}/products/{productId}")
-    public ResponseEntity<BfResponse<?>> updateProduct(
+    public ResponseEntity<BfResponse<Map<String, ProductResponseDto>>> updateProduct(
             @PathVariable Long storeId,
             @PathVariable Long productId,
             @Valid @RequestPart(value = "request") ProductUpdateDto productUpdateDto,

--- a/api/store/src/main/java/com/backtothefuture/store/controller/ProductController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/ProductController.java
@@ -8,17 +8,23 @@ import com.backtothefuture.domain.response.BfResponse;
 import com.backtothefuture.store.dto.request.ProductRegisterDto;
 import com.backtothefuture.store.dto.request.ProductUpdateDto;
 import com.backtothefuture.store.service.ProductService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -31,10 +37,25 @@ public class ProductController {
 
     // 상품 등록 API
     // TODO: ROLE 을 STORE_OWNER, ADMIN 제한
-    @PostMapping("/stores/{storeId}/products")
+    @Operation(summary = "새로운 상품 등록",
+            description = "특정 가게에 새로운 상품을 등록합니다. 이미지는 'image/png', 'image/jpeg' 형식을 지원합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "등록 성공",
+                            content = @Content(schema = @Schema(implementation = BfResponse.class),
+                                    examples = {
+                                            @ExampleObject(name = "success", value = "{\"code\": 201, \"message\": \"정상적으로 생성되었습니다.\", \"data\": {\"product_id\": 1}}")
+                                    }))
+            })
+    @PostMapping(
+            value = "/stores/{storeId}/products",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
     public ResponseEntity<BfResponse<?>> registerProduct(
             @PathVariable("storeId") Long storeId,
+            @Parameter(description = "요청 정보입니다.")
             @Valid @RequestPart(value = "request") ProductRegisterDto productRegisterDto,
+            @Parameter(description = "상품 이미지로 사용할 이미지를 첨부해 주세요.")
             @RequestPart(value = "file", required = false) MultipartFile thumbnail
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/api/store/src/main/java/com/backtothefuture/store/controller/StoreController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/StoreController.java
@@ -31,16 +31,15 @@ import org.springframework.web.multipart.MultipartFile;
 public class StoreController {
     private final StoreService storeService;
 
-
     @PostMapping(
             value = "",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
     @Operation(summary = "새로운 가게 등록",
-            description = "가게 정보와 이미지를 등록합니다. 이미지는 'image/png', 'image/jpg' 형식을 지원합니다.",
+            description = "가게 정보와 이미지를 등록합니다. 이미지는 'image/png', 'image/jpeg' 형식을 지원합니다.",
             responses = {
-                    @ApiResponse(responseCode = "201", description = "생성 성공",
+                    @ApiResponse(responseCode = "201", description = "등록 성공",
                             content = @Content(schema = @Schema(implementation = BfResponse.class),
                                     examples = {
                                             @ExampleObject(name = "success", value = "{\"code\": 201, \"message\": \"정상적으로 생성되었습니다.\", \"data\": {\"store_id\": 1}}")}))

--- a/api/store/src/main/java/com/backtothefuture/store/controller/StoreController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/StoreController.java
@@ -38,7 +38,7 @@ public class StoreController {
             produces = MediaType.APPLICATION_JSON_VALUE
     )
     @Operation(summary = "새로운 가게 등록",
-            description = "가게 정보와 선택적 썸네일을 등록합니다. 썸네일은 'image/png', 'image/jpg' 형식을 지원합니다.",
+            description = "가게 정보와 이미지를 등록합니다. 이미지는 'image/png', 'image/jpg' 형식을 지원합니다.",
             responses = {
                     @ApiResponse(responseCode = "201", description = "생성 성공",
                             content = @Content(schema = @Schema(implementation = BfResponse.class),

--- a/api/store/src/main/java/com/backtothefuture/store/controller/StoreController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/StoreController.java
@@ -6,10 +6,17 @@ import com.backtothefuture.domain.response.BfResponse;
 import com.backtothefuture.security.service.UserDetailsImpl;
 import com.backtothefuture.store.dto.request.StoreRegisterDto;
 import com.backtothefuture.store.service.StoreService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,10 +31,25 @@ import org.springframework.web.multipart.MultipartFile;
 public class StoreController {
     private final StoreService storeService;
 
-    @PostMapping("")
+
+    @PostMapping(
+            value = "",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @Operation(summary = "새로운 가게 등록",
+            description = "가게 정보와 선택적 썸네일을 등록합니다. 썸네일은 'image/png', 'image/jpg' 형식을 지원합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "생성 성공",
+                            content = @Content(schema = @Schema(implementation = BfResponse.class),
+                                    examples = {
+                                            @ExampleObject(name = "success", value = "{\"code\": 201, \"message\": \"정상적으로 생성되었습니다.\", \"data\": {\"store_id\": 1}}")}))
+            })
     public ResponseEntity<BfResponse<?>> registerStore(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "요청 정보입니다.")
             @Valid @RequestPart(value = "request") StoreRegisterDto storeRegisterDto,
+            @Parameter(description = "가게 이미지로 사용할 이미지를 첨부해 주세요.")
             @RequestPart(value = "file", required = false) MultipartFile thumbnail
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/api/store/src/main/java/com/backtothefuture/store/dto/request/ProductRegisterDto.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/request/ProductRegisterDto.java
@@ -2,6 +2,7 @@ package com.backtothefuture.store.dto.request;
 
 import com.backtothefuture.domain.product.Product;
 import com.backtothefuture.domain.store.Store;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -10,21 +11,26 @@ import java.util.Optional;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "상품 등록 정보(DTO)")
 public record ProductRegisterDto(
 
         @NotBlank(message = "상품 이름은 필수 항목입니다.")
         @Size(max = 20, message = "상품 이름은 최대 20자 이하로 입력해주세요.")
+        @Schema(description = "상품 이름", example = "크루아상", required = true)
         String name,
 
         @NotBlank(message = "상품 설명은 필수 항목입니다.")
         @Size(max = 50, message = "상품 설명은 최대 50자 이하로 입력해주세요.")
+        @Schema(description = "상품 설명", example = "프랑스 고메버터가 풍부하게 들어간 프랑스식 패스트리", required = true)
         String description,
 
         @Min(value = 0, message = "가격은 음수일 수 없습니다.")
         @Max(value = 1000000, message = "최대 100만원까지 입력 가능합니다.")
+        @Schema(description = "상품 가격 (단위: 원)", example = "3000", required = true)
         int price,
 
         @Min(value = 0, message = "재고는 음수일 수 없습니다.")
+        @Schema(description = "재고 수량 (기본값: 0)", example = "50", required = false)
         int stockQuantity // 재고 수량, optional, default 0
 
 ) {

--- a/api/store/src/main/java/com/backtothefuture/store/dto/request/StoreRegisterDto.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/request/StoreRegisterDto.java
@@ -3,6 +3,8 @@ package com.backtothefuture.store.dto.request;
 import com.backtothefuture.domain.member.Member;
 import com.backtothefuture.domain.store.Store;
 import com.backtothefuture.store.annotation.NumericStringList;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -12,29 +14,36 @@ import java.util.Optional;
 import lombok.Builder;
 import org.springframework.format.annotation.DateTimeFormat;
 
+@Schema(description = "가게 등록을 위한 데이터 전송 객체(DTO)")
 @Builder
 public record StoreRegisterDto(
         @NotBlank(message = "가게이름은 필수 항목입니다.")
         @Size(max = 20, message = "가게이름은 최대 20자 이하로 입력해주세요.")
+        @Schema(description = "가게 이름", example = "베이커리 카페", required = true)
         String name,
 
         @NotBlank(message = "가게설명은 필수 항목입니다.")
         @Size(max = 50, message = "가게설명은 최대 50자 이하로 입력해주세요.")
+        @Schema(description = "가게 설명", example = "신선한 빵과 커피를 제공하는 카페", required = true)
         String description,
 
         @NotBlank(message = "가게위치는 필수 항목입니다.")
         @Size(max = 50, message = "가게위치는 최대 50자 이하로 입력해주세요.")
+        @Schema(description = "가게 위치", example = "서울시 강남구 역삼동 123-45", required = true)
         String location,
 
         @NumericStringList(message = "연락처는 숫자만 입력할 수 있습니다.")
+        @ArraySchema(arraySchema = @Schema(description = "가게 연락처", example = "[\"010\", \"0000\", \"0000\"]"))
         List<String> contact,
 
         @DateTimeFormat(pattern = "HH:mm")
         @NotNull(message = "오픈 시간은 필수 입니다.")
+        @Schema(description = "오픈 시간", example = "09:00", required = true)
         LocalTime startTime,
 
         @DateTimeFormat(pattern = "HH:mm")
         @NotNull(message = "마감 시간은 필수 입니다.")
+        @Schema(description = "마감 시간", example = "22:00", required = true)
         LocalTime endTime
 ) {
 

--- a/api/store/src/main/java/com/backtothefuture/store/dto/response/ProductGetListResponseDto.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/response/ProductGetListResponseDto.java
@@ -1,0 +1,8 @@
+package com.backtothefuture.store.dto.response;
+
+import java.util.List;
+
+public record ProductGetListResponseDto(
+        List<ProductResponseDto> products
+) {
+}

--- a/api/store/src/main/java/com/backtothefuture/store/dto/response/ProductGetOneResponseDto.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/response/ProductGetOneResponseDto.java
@@ -1,0 +1,7 @@
+package com.backtothefuture.store.dto.response;
+
+public record ProductGetOneResponseDto(
+        ProductResponseDto product
+) {
+
+}

--- a/api/store/src/main/java/com/backtothefuture/store/service/ProductService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/ProductService.java
@@ -51,13 +51,15 @@ public class ProductService {
         Long id = productRepository.save(product).getId();
 
         // 이미지 업로드
-        try {
-            String imageUrl = s3Util.uploadProductThumbnail(String.valueOf(storeId), String.valueOf(id), thumbnail);
-            product.setThumbnailUrl(imageUrl);
-        } catch (IllegalArgumentException e) {
-            throw new ProductException(UNSUPPORTED_IMAGE_EXTENSION);
-        } catch (IOException e) {
-            throw new ProductException(IMAGE_UPLOAD_FAIL);
+        if (thumbnail != null) {
+            try {
+                String imageUrl = s3Util.uploadProductThumbnail(String.valueOf(storeId), String.valueOf(id), thumbnail);
+                product.setThumbnailUrl(imageUrl);
+            } catch (IllegalArgumentException e) {
+                throw new ProductException(UNSUPPORTED_IMAGE_EXTENSION);
+            } catch (IOException e) {
+                throw new ProductException(IMAGE_UPLOAD_FAIL);
+            }
         }
 
         return id;

--- a/api/store/src/main/java/com/backtothefuture/store/service/ProductService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/ProductService.java
@@ -17,6 +17,7 @@ import com.backtothefuture.security.exception.CustomSecurityException;
 import com.backtothefuture.security.service.UserDetailsImpl;
 import com.backtothefuture.store.dto.request.ProductRegisterDto;
 import com.backtothefuture.store.dto.request.ProductUpdateDto;
+import com.backtothefuture.store.dto.response.ProductGetOneResponseDto;
 import com.backtothefuture.store.dto.response.ProductResponseDto;
 import com.backtothefuture.store.exception.ProductException;
 import java.io.IOException;
@@ -66,7 +67,7 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public ProductResponseDto getProduct(Long storeId, Long productId) {
+    public ProductGetOneResponseDto getProduct(Long storeId, Long productId) {
 
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new ProductException(NOT_FOUND_PRODUCT_ID));
@@ -75,14 +76,15 @@ public class ProductService {
             throw new ProductException(NOT_FOUND_STORE_PRODUCT_MATCH);
         }
 
-        return ProductResponseDto.builder()
-                .id(product.getId())
-                .name(product.getName())
-                .description(product.getDescription())
-                .price(product.getPrice())
-                .stockQuantity(product.getStockQuantity())
-                .thumbnail(product.getThumbnail())
-                .build();
+        return new ProductGetOneResponseDto(
+                ProductResponseDto.builder()
+                        .id(product.getId())
+                        .name(product.getName())
+                        .description(product.getDescription())
+                        .price(product.getPrice())
+                        .stockQuantity(product.getStockQuantity())
+                        .thumbnail(product.getThumbnail())
+                        .build());
     }
 
     @Transactional(readOnly = true)

--- a/api/store/src/main/java/com/backtothefuture/store/service/ProductService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/ProductService.java
@@ -17,6 +17,7 @@ import com.backtothefuture.security.exception.CustomSecurityException;
 import com.backtothefuture.security.service.UserDetailsImpl;
 import com.backtothefuture.store.dto.request.ProductRegisterDto;
 import com.backtothefuture.store.dto.request.ProductUpdateDto;
+import com.backtothefuture.store.dto.response.ProductGetListResponseDto;
 import com.backtothefuture.store.dto.response.ProductGetOneResponseDto;
 import com.backtothefuture.store.dto.response.ProductResponseDto;
 import com.backtothefuture.store.exception.ProductException;
@@ -88,8 +89,8 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProductResponseDto> getAllProducts() {
-        return productRepository.findAll().stream()
+    public ProductGetListResponseDto getAllProducts() {
+        List<ProductResponseDto> products = productRepository.findAll().stream()
                 .map(product -> ProductResponseDto.builder()
                         .id(product.getId())
                         .name(product.getName())
@@ -99,11 +100,13 @@ public class ProductService {
                         .thumbnail(product.getThumbnail())
                         .build())
                 .collect(Collectors.toList());
+        return new ProductGetListResponseDto(products);
     }
 
     @Transactional
-    public ProductResponseDto partialUpdateProduct(Long storeId, Long productId, ProductUpdateDto productUpdateDto,
-                                                   MultipartFile thumbnail) {
+    public ProductGetOneResponseDto partialUpdateProduct(Long storeId, Long productId,
+                                                         ProductUpdateDto productUpdateDto,
+                                                         MultipartFile thumbnail) {
         // 권한 검사
         if (!validateIsProductOwner(storeId, productId)) {
             throw new ProductException(FORBIDDEN_DELETE_PRODUCT);
@@ -135,7 +138,7 @@ public class ProductService {
 
         }
 
-        return ProductResponseDto.builder()
+        ProductResponseDto productResponseDto = ProductResponseDto.builder()
                 .id(product.getId())
                 .name(product.getName())
                 .description(product.getDescription())
@@ -143,6 +146,8 @@ public class ProductService {
                 .stockQuantity(product.getStockQuantity())
                 .thumbnail(product.getThumbnail())
                 .build();
+
+        return new ProductGetOneResponseDto(productResponseDto);
     }
 
     @Transactional

--- a/api/store/src/main/java/com/backtothefuture/store/service/StoreService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/StoreService.java
@@ -47,15 +47,17 @@ public class StoreService {
         Long id = storeRepository.save(store).getId();
 
         // 이미지 업로드
-        try {
-            String imageUrl = s3Util.uploadStoreThumbnail(String.valueOf(id), thumbnail);
-            store.setThumbnailUrl(imageUrl);
-        } catch (IllegalArgumentException e) {
-            throw new StoreException(UNSUPPORTED_IMAGE_EXTENSION);
-        } catch (IOException e) {
-            throw new StoreException(IMAGE_UPLOAD_FAIL);
+        if (thumbnail != null) {
+            try {
+                String imageUrl = s3Util.uploadStoreThumbnail(String.valueOf(id), thumbnail);
+                store.setThumbnailUrl(imageUrl);
+            } catch (IllegalArgumentException e) {
+                throw new StoreException(UNSUPPORTED_IMAGE_EXTENSION);
+            } catch (IOException e) {
+                throw new StoreException(IMAGE_UPLOAD_FAIL);
+            }
         }
-
+        
         return id;
     }
 }

--- a/api/store/src/test/java/com/backtothefuture/store/controller/ProductControllerTest.java
+++ b/api/store/src/test/java/com/backtothefuture/store/controller/ProductControllerTest.java
@@ -10,6 +10,8 @@ import com.backtothefuture.domain.common.util.s3.S3AsyncUtil;
 import com.backtothefuture.domain.common.util.s3.S3Util;
 import com.backtothefuture.infra.config.BfTestConfig;
 import com.backtothefuture.infra.config.S3Config;
+import com.backtothefuture.store.dto.response.ProductGetListResponseDto;
+import com.backtothefuture.store.dto.response.ProductGetOneResponseDto;
 import com.backtothefuture.store.dto.response.ProductResponseDto;
 import com.backtothefuture.store.service.ProductService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -66,7 +68,9 @@ class ProductControllerTest extends BfTestConfig {
         Long productId = 1L;
         ProductResponseDto productResponseDto = new ProductResponseDto(productId, "상품1", "상품1 설명", 10000, 10,
                 "thumbnail1");
-        when(productService.getProduct(storeId, productId)).thenReturn(productResponseDto);
+        ProductGetOneResponseDto productGetOneResponseDto = new ProductGetOneResponseDto(productResponseDto);
+
+        when(productService.getProduct(storeId, productId)).thenReturn(productGetOneResponseDto);
 
         // when & then
         this.mockMvc.perform(get("/stores/{storeId}/products/{productId}", storeId, productId)
@@ -81,7 +85,8 @@ class ProductControllerTest extends BfTestConfig {
         List<ProductResponseDto> products = List.of(
                 new ProductResponseDto(1L, "상품1", "상품1 설명", 10000, 10, "thumbnail1"),
                 new ProductResponseDto(2L, "상품2", "상품2 설명", 20000, 20, "thumbnail2"));
-        when(productService.getAllProducts()).thenReturn(products);
+        ProductGetListResponseDto productGetListResponseDto = new ProductGetListResponseDto(products);
+        when(productService.getAllProducts()).thenReturn(productGetListResponseDto);
 
         // when & then
         this.mockMvc.perform(get("/products")

--- a/core/infra/src/main/java/com/backtothefuture/infra/config/MultipartJackson2HttpMessageConverter.java
+++ b/core/infra/src/main/java/com/backtothefuture/infra/config/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,34 @@
+package com.backtothefuture.infra.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Type;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    /**
+     * HttpMediaTypeNotSupportedException: Content-Type 'application/octet-stream' is not supported 문제를 위한 설정 Converter
+     * for support http request with header Content-Type: multipart/form-data
+     */
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/docs/openapi/store-openapi.yaml
+++ b/docs/openapi/store-openapi.yaml
@@ -14,7 +14,7 @@ paths:
       tags:
       - store-controller
       summary: 새로운 가게 등록
-      description: "가게 정보와 이미지를 등록합니다. 이미지는 'image/png', 'image/jpg' 형식을 지원합니다."
+      description: "가게 정보와 이미지를 등록합니다. 이미지는 'image/png', 'image/jpeg' 형식을 지원합니다."
       operationId: registerStore
       requestBody:
         content:
@@ -32,7 +32,7 @@ paths:
                   format: binary
       responses:
         "201":
-          description: 생성 성공
+          description: 등록 성공
           content:
             application/json:
               schema:
@@ -49,6 +49,9 @@ paths:
     post:
       tags:
       - product-controller
+      summary: 새로운 상품 등록
+      description: "특정 가게에 새로운 상품을 등록합니다. 이미지는 'image/png', 'image/jpeg' 형식을 지원합니다\
+        ."
       operationId: registerProduct
       parameters:
       - name: storeId
@@ -59,7 +62,7 @@ paths:
           format: int64
       requestBody:
         content:
-          application/json:
+          multipart/form-data:
             schema:
               required:
               - request
@@ -69,14 +72,23 @@ paths:
                   $ref: '#/components/schemas/ProductRegisterDto'
                 file:
                   type: string
+                  description: 상품 이미지로 사용할 이미지를 첨부해 주세요.
                   format: binary
       responses:
-        "200":
-          description: OK
+        "201":
+          description: 등록 성공
           content:
-            '*/*':
+            application/json:
               schema:
-                $ref: '#/components/schemas/BfResponseObject'
+                $ref: '#/components/schemas/BfResponse'
+              examples:
+                success:
+                  description: success
+                  value:
+                    code: 201
+                    message: 정상적으로 생성되었습니다.
+                    data:
+                      product_id: 1
   /reservations:
     post:
       tags:
@@ -341,35 +353,35 @@ components:
       required:
       - description
       - name
+      - price
       type: object
       properties:
         name:
           maxLength: 20
           minLength: 0
           type: string
+          description: 상품 이름
+          example: 크루아상
         description:
           maxLength: 50
           minLength: 0
           type: string
+          description: 상품 설명
+          example: 프랑스 고메버터가 풍부하게 들어간 프랑스식 패스트리
         price:
           maximum: 1000000
           minimum: 0
           type: integer
+          description: "상품 가격 (단위: 원)"
           format: int32
+          example: 3000
         stockQuantity:
           minimum: 0
           type: integer
+          description: "재고 수량 (기본값: 0)"
           format: int32
-    BfResponseObject:
-      type: object
-      properties:
-        code:
-          type: integer
-          format: int32
-        message:
-          type: string
-        data:
-          type: object
+          example: 50
+      description: 요청 정보입니다.
     ReservationRequestDto:
       required:
       - reservationTime
@@ -400,6 +412,16 @@ components:
           minimum: 0
           type: integer
           format: int32
+    BfResponseObject:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+        data:
+          type: object
     ProductUpdateDto:
       type: object
       properties:

--- a/docs/openapi/store-openapi.yaml
+++ b/docs/openapi/store-openapi.yaml
@@ -111,16 +111,20 @@ paths:
     get:
       tags:
       - product-controller
+      summary: 상품 정보 조회
+      description: 특정 가게의 특정 상품에 대한 자세한 정보를 조회합니다.
       operationId: getProduct
       parameters:
       - name: storeId
         in: path
+        description: 가게 ID
         required: true
         schema:
           type: integer
           format: int64
       - name: productId
         in: path
+        description: 상품 ID
         required: true
         schema:
           type: integer
@@ -131,34 +135,37 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: '#/components/schemas/BfResponseObject'
+                $ref: '#/components/schemas/BfResponseProductGetOneResponseDto'
+      security: []
     delete:
       tags:
       - product-controller
+      summary: 싱픔 삭제
       operationId: deleteProduct
       parameters:
       - name: storeId
         in: path
+        description: 가게 ID
         required: true
         schema:
           type: integer
           format: int64
       - name: productId
         in: path
+        description: 상품 ID
         required: true
         schema:
           type: integer
           format: int64
       responses:
-        "200":
-          description: OK
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/BfResponseObject'
+        "204":
+          description: 삭제 성공
     patch:
       tags:
       - product-controller
+      summary: 상품 부분 수정
+      description: "상품 정보를 부분적으로 수정합니다. 수정하지 않는 정보는 요청 정보에 포함하지 않습니다. 이미지는 'image/png',\
+        \ 'image/jpeg' 형식을 지원합니다."
       operationId: updateProduct
       parameters:
       - name: storeId
@@ -175,7 +182,7 @@ paths:
           format: int64
       requestBody:
         content:
-          application/json:
+          multipart/form-data:
             schema:
               required:
               - request
@@ -190,9 +197,9 @@ paths:
         "200":
           description: OK
           content:
-            '*/*':
+            application/json:
               schema:
-                $ref: '#/components/schemas/BfResponseObject'
+                $ref: '#/components/schemas/BfResponseProductGetOneResponseDto'
   /reservations/{reservationId}:
     get:
       tags:
@@ -271,6 +278,8 @@ paths:
     get:
       tags:
       - product-controller
+      summary: 모든 상품 정보 조회
+      description: "모든 상품을 조회합니다. TODO: 정렬기준, pagenation 추가"
       operationId: getAllProducts
       responses:
         "200":
@@ -278,7 +287,8 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: '#/components/schemas/BfResponseObject'
+                $ref: '#/components/schemas/BfResponseProductGetListResponseDto'
+      security: []
 components:
   schemas:
     BfResponse:
@@ -442,6 +452,56 @@ components:
           minimum: 0
           type: integer
           format: int32
+    BfResponseProductGetOneResponseDto:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+        data:
+          $ref: '#/components/schemas/ProductGetOneResponseDto'
+    ProductGetOneResponseDto:
+      type: object
+      properties:
+        product:
+          $ref: '#/components/schemas/ProductResponseDto'
+    ProductResponseDto:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        description:
+          type: string
+        price:
+          type: integer
+          format: int32
+        stockQuantity:
+          type: integer
+          format: int32
+        thumbnail:
+          type: string
+    BfResponseProductGetListResponseDto:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+        data:
+          $ref: '#/components/schemas/ProductGetListResponseDto'
+    ProductGetListResponseDto:
+      type: object
+      properties:
+        products:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProductResponseDto'
   securitySchemes:
     Authorization:
       type: http

--- a/docs/openapi/store-openapi.yaml
+++ b/docs/openapi/store-openapi.yaml
@@ -1,647 +1,428 @@
 openapi: 3.0.1
 info:
-  title: Bag To the Future
-  description: API Documentation
-  version: 0.1.0
+  title: 백투더퓨처 API Documentation
+  description: 백투더퓨처 API 문서입니다.
+  version: v1.0.0
 servers:
 - url: http://localhost:8081/v1
-tags: []
+  description: Generated server url
+security:
+- Authorization: []
 paths:
-  /products:
-    get:
-      tags:
-      - products
-      summary: 모든 상품 조회 API
-      description: 모든 상품 조회 API입니다.
-      operationId: get-all-products
-      responses:
-        "200":
-          description: "200"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/[response] get-all-products"
-              examples:
-                get-all-products:
-                  value: "{\"code\":200,\"message\":\"정상 처리되었습니다.\",\"data\":{\"products\"\
-                    :[{\"id\":1,\"name\":\"상품1\",\"description\":\"상품1 설명\",\"price\"\
-                    :10000,\"stockQuantity\":10,\"thumbnail\":\"thumbnail1\"},{\"\
-                    id\":2,\"name\":\"상품2\",\"description\":\"상품2 설명\",\"price\":20000,\"\
-                    stockQuantity\":20,\"thumbnail\":\"thumbnail2\"}]}}"
-  /reservations:
-    post:
-      tags:
-      - reservations
-      summary: 구매자 예약 API
-      description: 구매자 예약하기 API입니다.
-      operationId: make-reservation
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/[request] make-reservation"
-            examples:
-              make-reservation:
-                value: "{\"storeId\":1,\"orderRequestItems\":[{\"productId\":1,\"\
-                  quantity\":1},{\"productId\":2,\"quantity\":1}],\"reservationTime\"\
-                  :\"12:00:00\"}"
-      responses:
-        "201":
-          description: "201"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/[response] make-reservation"
-              examples:
-                make-reservation:
-                  value: "{\"code\":201,\"message\":\"정상적으로 생성되었습니다.\",\"data\":{\"\
-                    reservation_id\":1}}"
-  /reservations/{reservationId}:
-    get:
-      tags:
-      - reservations
-      summary: 구매자 예약 조회 API
-      description: 구매자 예약 조회 API입니다.
-      operationId: get-reservation
-      parameters:
-      - name: reservationId
-        in: path
-        description: 예약 ID
-        required: true
-        schema:
-          type: number
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/reservations-reservationId486549215'
-            examples:
-              get-reservation:
-                value: "[{\"name\":\"product1\",\"count\":1,\"price\":1000},{\"name\"\
-                  :\"product2\",\"count\":2,\"price\":2000}]"
-      responses:
-        "200":
-          description: "200"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/[response] make-reservation"
-              examples:
-                get-reservation:
-                  value: "{\"code\":200,\"message\":\"정상 처리되었습니다.\",\"data\":[{\"\
-                    name\":\"product1\",\"count\":1,\"price\":1000},{\"name\":\"product2\"\
-                    ,\"count\":2,\"price\":2000}]}"
-    delete:
-      tags:
-      - reservations
-      summary: 구매자 예약 취소 API
-      description: 구매자 예약 취소 API입니다.
-      operationId: cancel-reservation
-      parameters:
-      - name: reservationId
-        in: path
-        description: 예약 ID
-        required: true
-        schema:
-          type: number
-      responses:
-        "204":
-          description: "204"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/[response] cancel-reservation"
-              examples:
-                cancel-reservation:
-                  value: "{\"code\":200,\"message\":\"정상 처리되었습니다.\",\"data\":\"NO_CONTENT\"\
-                    }"
   /stores:
     post:
       tags:
-      - stores
-      summary: 가게 등록 API
-      description: 가게 등록 API 입니다.
-      operationId: register-store
-      parameters:
-      - name: Authorization
-        in: header
-        description: "JWT 인증 토큰. 'Bearer ${Jwt Token}' 형식으로 입력해 주세요."
-        required: true
-        schema:
-          type: string
-        example: "Bearer ${JWT Token}"
+      - store-controller
+      summary: 새로운 가게 등록
+      description: "가게 정보와 이미지를 등록합니다. 이미지는 'image/png', 'image/jpg' 형식을 지원합니다."
+      operationId: registerStore
       requestBody:
         content:
-          application/json:
+          multipart/form-data:
             schema:
-              $ref: "#/components/schemas/[request] store-register"
-            examples:
-              register-store:
-                value: "{\"name\":\"가게 이름\",\"description\":\"가게 설명\",\"location\"\
-                  :\"가게 위치\",\"contact\":[\"010\",\"0000\",\"0000\"],\"image\":\"이\
-                  미지 url\",\"startTime\":\"10:00:00\",\"endTime\":\"21:00:00\"}"
+              required:
+              - request
+              type: object
+              properties:
+                request:
+                  $ref: '#/components/schemas/StoreRegisterDto'
+                file:
+                  type: string
+                  description: 가게 이미지로 사용할 이미지를 첨부해 주세요.
+                  format: binary
       responses:
         "201":
-          description: "201"
+          description: 생성 성공
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/[response] store-register"
+                $ref: '#/components/schemas/BfResponse'
               examples:
-                register-store:
-                  value: "{\"code\":201,\"message\":\"정상적으로 생성되었습니다.\",\"data\":{\"\
-                    store_id\":1}}"
+                success:
+                  description: success
+                  value:
+                    code: 201
+                    message: 정상적으로 생성되었습니다.
+                    data:
+                      store_id: 1
   /stores/{storeId}/products:
     post:
       tags:
-      - products
-      summary: 상품 등록 API
-      description: 상품 등록 API 입니다.
-      operationId: register-product
+      - product-controller
+      operationId: registerProduct
       parameters:
       - name: storeId
         in: path
-        description: 가게 ID
         required: true
         schema:
-          type: number
-      - name: Authorization
-        in: header
-        description: "JWT 인증 토큰. 'Bearer ${Jwt Token}' 형식으로 입력해 주세요."
-        required: true
-        schema:
-          type: string
-        example: "Bearer ${JWT Token}"
+          type: integer
+          format: int64
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/[request] product-register"
-            examples:
-              register-product:
-                value: "{\"name\":\"상품 이름\",\"description\":\"상품 설명\",\"price\":10000,\"\
-                  stockQuantity\":1,\"thumbnail\":\"이미지 링크\"}"
+              required:
+              - request
+              type: object
+              properties:
+                request:
+                  $ref: '#/components/schemas/ProductRegisterDto'
+                file:
+                  type: string
+                  format: binary
       responses:
-        "201":
-          description: "201"
+        "200":
+          description: OK
           content:
-            application/json:
+            '*/*':
               schema:
-                $ref: "#/components/schemas/[response] product-register"
-              examples:
-                register-product:
-                  value: "{\"code\":201,\"message\":\"정상적으로 생성되었습니다.\",\"data\":{\"\
-                    product_id\":1}}"
+                $ref: '#/components/schemas/BfResponseObject'
+  /reservations:
+    post:
+      tags:
+      - reservation-controller
+      operationId: makeReservation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReservationRequestDto'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/BfResponseObject'
   /stores/{storeId}/products/{productId}:
     get:
       tags:
-      - products
-      summary: 상품 단건 조회 API
-      description: 상품 단건 조회 API입니다.
-      operationId: get-product-by-store
+      - product-controller
+      operationId: getProduct
       parameters:
       - name: storeId
         in: path
-        description: 가게 ID
         required: true
         schema:
-          type: number
+          type: integer
+          format: int64
       - name: productId
         in: path
-        description: 상품 ID
         required: true
         schema:
-          type: number
+          type: integer
+          format: int64
       responses:
         "200":
-          description: "200"
+          description: OK
           content:
-            application/json:
+            '*/*':
               schema:
-                $ref: "#/components/schemas/[response] get-product"
-              examples:
-                get-product-by-store:
-                  value: "{\"code\":200,\"message\":\"정상 처리되었습니다.\",\"data\":{\"product\"\
-                    :{\"id\":1,\"name\":\"상품1\",\"description\":\"상품1 설명\",\"price\"\
-                    :10000,\"stockQuantity\":10,\"thumbnail\":\"thumbnail1\"}}}"
+                $ref: '#/components/schemas/BfResponseObject'
     delete:
       tags:
-      - products
-      summary: 상품 삭제 API
-      description: 상품 삭제 API 입니다.
-      operationId: delete-product
+      - product-controller
+      operationId: deleteProduct
       parameters:
       - name: storeId
         in: path
-        description: 가게 ID
         required: true
         schema:
-          type: number
+          type: integer
+          format: int64
       - name: productId
         in: path
-        description: 상품 ID
         required: true
         schema:
-          type: number
-      - name: Authorization
-        in: header
-        description: "JWT 인증 토큰. 'Bearer ${Jwt Token}' 형식으로 입력해 주세요."
-        required: true
-        schema:
-          type: string
-        example: "Bearer ${JWT Token}"
+          type: integer
+          format: int64
       responses:
-        "204":
-          description: "204"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/BfResponseObject'
     patch:
       tags:
-      - products
-      summary: 상품 업데이트 API
-      description: 상품 업데이트 API 입니다. 업데이트 할 항목만 보내주세요.
-      operationId: update-product
+      - product-controller
+      operationId: updateProduct
       parameters:
       - name: storeId
         in: path
-        description: 가게 ID
         required: true
         schema:
-          type: number
+          type: integer
+          format: int64
       - name: productId
         in: path
-        description: 상품 ID
         required: true
         schema:
-          type: number
+          type: integer
+          format: int64
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/[reqyest] update-product"
-            examples:
-              update-product:
-                value: "{\"name\":\"업데이트된 상품 이름\",\"description\":\"업데이트된 상품 설명\"\
-                  ,\"price\":15000,\"stockQuantity\":5,\"thumbnail\":\"업데이트된 이미지 링\
-                  크\"}"
+              required:
+              - request
+              type: object
+              properties:
+                request:
+                  $ref: '#/components/schemas/ProductUpdateDto'
+                file:
+                  type: string
+                  format: binary
       responses:
         "200":
-          description: "200"
+          description: OK
           content:
-            application/json:
+            '*/*':
               schema:
-                $ref: "#/components/schemas/[response] update-product"
-              examples:
-                update-product:
-                  value: "{\"code\":200,\"message\":\"정상 처리되었습니다.\",\"data\":{\"product\"\
-                    :{\"id\":1,\"name\":\"업데이트된 상품 이름\",\"description\":\"업데이트된 상품\
-                    \ 설명\",\"price\":15000,\"stockQuantity\":5,\"thumbnail\":\"업데이\
-                    트된 이미지 링크\"}}}"
+                $ref: '#/components/schemas/BfResponseObject'
+  /reservations/{reservationId}:
+    get:
+      tags:
+      - reservation-controller
+      operationId: getReservation
+      parameters:
+      - name: reservationId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/BfResponseObject'
+    delete:
+      tags:
+      - reservation-controller
+      operationId: cancelReservation
+      parameters:
+      - name: reservationId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/BfResponseObject'
+  /reservations/proceeding:
+    get:
+      tags:
+      - reservation-controller
+      operationId: getMemberProceedingReservations
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/BfResponseObject'
+  /reservations/done:
+    get:
+      tags:
+      - reservation-controller
+      operationId: getMemberDoneReservations
+      parameters:
+      - name: cursorId
+        in: query
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: size
+        in: query
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/BfResponseObject'
+  /products:
+    get:
+      tags:
+      - product-controller
+      operationId: getAllProducts
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/BfResponseObject'
 components:
   schemas:
-    '[request] make-reservation':
-      title: "[request] make-reservation"
+    BfResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+        data:
+          type: object
+    LocalTime:
+      type: object
+      properties:
+        hour:
+          type: integer
+          format: int32
+        minute:
+          type: integer
+          format: int32
+        second:
+          type: integer
+          format: int32
+        nano:
+          type: integer
+          format: int32
+      description: 마감 시간
+      example: 22:00
+    StoreRegisterDto:
+      required:
+      - description
+      - endTime
+      - location
+      - name
+      - startTime
+      type: object
+      properties:
+        name:
+          maxLength: 20
+          minLength: 0
+          type: string
+          description: 가게 이름
+          example: 베이커리 카페
+        description:
+          maxLength: 50
+          minLength: 0
+          type: string
+          description: 가게 설명
+          example: 신선한 빵과 커피를 제공하는 카페
+        location:
+          maxLength: 50
+          minLength: 0
+          type: string
+          description: 가게 위치
+          example: 서울시 강남구 역삼동 123-45
+        contact:
+          type: array
+          description: 가게 연락처
+          example:
+          - "010"
+          - "0000"
+          - "0000"
+          items:
+            type: string
+        startTime:
+          $ref: '#/components/schemas/LocalTime'
+        endTime:
+          $ref: '#/components/schemas/LocalTime'
+      description: 요청 정보입니다.
+    ProductRegisterDto:
+      required:
+      - description
+      - name
+      type: object
+      properties:
+        name:
+          maxLength: 20
+          minLength: 0
+          type: string
+        description:
+          maxLength: 50
+          minLength: 0
+          type: string
+        price:
+          maximum: 1000000
+          minimum: 0
+          type: integer
+          format: int32
+        stockQuantity:
+          minimum: 0
+          type: integer
+          format: int32
+    BfResponseObject:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+        data:
+          type: object
+    ReservationRequestDto:
       required:
       - reservationTime
       - storeId
       type: object
       properties:
+        storeId:
+          type: integer
+          format: int64
         orderRequestItems:
+          maxItems: 2147483647
+          minItems: 1
           type: array
           items:
-            required:
-            - productId
-            - quantity
-            type: object
-            properties:
-              quantity:
-                type: number
-                description: 주문한 수량 값입니다.
-              productId:
-                type: number
-                description: 상품 ID 값입니다.
+            $ref: '#/components/schemas/ReservationRequestItemDto'
         reservationTime:
           type: string
-          description: 예약 시간입니다. 'HH:mm' 형태입니다.
-        storeId:
-          type: number
-          description: 가게 ID 값입니다.
-    '[reqyest] update-product':
-      title: "[reqyest] update-product"
+          format: date-time
+    ReservationRequestItemDto:
+      required:
+      - productId
       type: object
       properties:
-        thumbnail:
+        productId:
+          type: integer
+          format: int64
+        quantity:
+          minimum: 0
+          type: integer
+          format: int32
+    ProductUpdateDto:
+      type: object
+      properties:
+        name:
+          maxLength: 20
+          minLength: 0
           type: string
-          description: 썸네일 이미지 입니다.
-          nullable: true
+        description:
+          maxLength: 50
+          minLength: 0
+          type: string
         price:
-          type: number
-          description: 상품 가격입니다. 0 이상의 수를 입력해주세요.
-          nullable: true
-        name:
-          type: string
-          description: 상품 이름입니다.
-          nullable: true
+          maximum: 1000000
+          minimum: 0
+          type: integer
+          format: int32
         stockQuantity:
-          type: number
-          description: 상품 재고입니다. 0 이상의 수를 입력해주세요.
-          nullable: true
-        description:
-          type: string
-          description: 상품 상세 설명입니다.
-          nullable: true
-    '[response] cancel-reservation':
-      title: "[response] cancel-reservation"
-      required:
-      - code
-      - data
-      - message
-      type: object
-      properties:
-        code:
-          type: number
-          description: HttpStatusCode 입니다.
-        data:
-          type: string
-          description: NO_CONTENT
-        message:
-          type: string
-          description: 응답 메시지 입니다.
-    '[response] get-all-products':
-      title: "[response] get-all-products"
-      required:
-      - code
-      - message
-      type: object
-      properties:
-        code:
-          type: number
-          description: HttpStatusCode 입니다.
-        data:
-          type: object
-          properties:
-            products:
-              type: array
-              items:
-                required:
-                - description
-                - id
-                - name
-                - price
-                - stockQuantity
-                - thumbnail
-                type: object
-                properties:
-                  thumbnail:
-                    type: string
-                    description: 썸네일 이미지 URL
-                  price:
-                    type: number
-                    description: 상품 가격
-                  name:
-                    type: string
-                    description: 상품 이름
-                  stockQuantity:
-                    type: number
-                    description: 재고 수량
-                  description:
-                    type: string
-                    description: 상품 설명
-                  id:
-                    type: number
-                    description: 상품 ID
-        message:
-          type: string
-          description: 응답 메시지 입니다.
-    '[request] product-register':
-      title: "[request] product-register"
-      required:
-      - description
-      - name
-      - price
-      type: object
-      properties:
-        thumbnail:
-          type: string
-          description: 썸네일 이미지 입니다.
-          nullable: true
-        price:
-          type: number
-          description: 상품 가격입니다. 0 이상의 수를 입력해주세요.
-        name:
-          type: string
-          description: 상품 이름입니다.
-        stockQuantity:
-          type: number
-          description: 상품 재고입니다. 0 이상의 수를 입력해주세요. 기본값은 0입니다.
-          nullable: true
-        description:
-          type: string
-          description: 상품 상세 설명입니다.
-    '[response] get-product':
-      title: "[response] get-product"
-      required:
-      - code
-      - message
-      type: object
-      properties:
-        code:
-          type: number
-          description: HttpStatusCode 입니다.
-        data:
-          type: object
-          properties:
-            product:
-              required:
-              - description
-              - id
-              - name
-              - price
-              - stockQuantity
-              - thumbnail
-              type: object
-              properties:
-                thumbnail:
-                  type: string
-                  description: 썸네일 이미지 URL
-                price:
-                  type: number
-                  description: 상품 가격
-                name:
-                  type: string
-                  description: 상품 이름
-                stockQuantity:
-                  type: number
-                  description: 재고 수량
-                description:
-                  type: string
-                  description: 상품 설명
-                id:
-                  type: number
-                  description: 상품 ID
-        message:
-          type: string
-          description: 응답 메시지 입니다.
-    '[response] store-register':
-      title: "[response] store-register"
-      required:
-      - code
-      - message
-      type: object
-      properties:
-        code:
-          type: number
-          description: HttpStatusCode 입니다.
-        data:
-          required:
-          - store_id
-          type: object
-          properties:
-            store_id:
-              type: number
-              description: 생성된 가게 ID 입니다.
-        message:
-          type: string
-          description: 응답 메시지 입니다.
-    '[response] make-reservation':
-      title: "[response] make-reservation"
-      required:
-      - code
-      - message
-      type: object
-      properties:
-        code:
-          type: number
-          description: HttpStatusCode 입니다.
-        data:
-          type: array
-          items:
-            required:
-            - count
-            - name
-            - price
-            type: object
-            properties:
-              price:
-                type: string
-                description: 주문된 각 상품의 금액입니다.
-              count:
-                type: string
-                description: 주문된 각 상품의 수량입니다.
-              name:
-                type: string
-                description: 상품 이름입니다.
-        message:
-          type: string
-          description: 응답 메시지 입니다.
-    '[request] store-register':
-      title: "[request] store-register"
-      required:
-      - description
-      - location
-      - name
-      type: object
-      properties:
-        image:
-          type: string
-          description: 썸네일 이미지 입니다.
-          nullable: true
-        contact:
-          type: array
-          description: 연락처입니다. 문자열 배열로 입력해주세요.
-          nullable: true
-          items:
-            oneOf:
-            - type: object
-            - type: boolean
-            - type: string
-            - type: number
-        name:
-          type: string
-          description: 가게 이름입니다.
-        description:
-          type: string
-          description: 가게 상세 설명입니다.
-        startTime:
-          type: string
-          description: 오픈시간입니다. HH:mm 형태
-          nullable: true
-        location:
-          type: number
-          description: 가게 위치입니다.
-        endTime:
-          type: string
-          description: 마감시간입니다. HH:mm 형태
-          nullable: true
-    '[response] update-product':
-      title: "[response] update-product"
-      required:
-      - code
-      - message
-      type: object
-      properties:
-        code:
-          type: number
-          description: HttpStatusCode 입니다.
-        data:
-          type: object
-          properties:
-            product:
-              required:
-              - description
-              - id
-              - name
-              - price
-              - stockQuantity
-              - thumbnail
-              type: object
-              properties:
-                thumbnail:
-                  type: string
-                  description: 썸네일 이미지 URL
-                price:
-                  type: number
-                  description: 상품 가격
-                name:
-                  type: string
-                  description: 상품 이름
-                stockQuantity:
-                  type: number
-                  description: 재고 수량
-                description:
-                  type: string
-                  description: 상품 설명
-                id:
-                  type: number
-                  description: 상품 ID
-        message:
-          type: string
-          description: 응답 메시지 입니다.
-    '[response] product-register':
-      title: "[response] product-register"
-      required:
-      - code
-      - message
-      type: object
-      properties:
-        code:
-          type: number
-          description: HttpStatusCode 입니다.
-        data:
-          required:
-          - product_id
-          type: object
-          properties:
-            product_id:
-              type: number
-              description: 생성된 상품 ID 입니다.
-        message:
-          type: string
-          description: 응답 메시지 입니다.
-    reservations-reservationId486549215:
-      type: object
+          minimum: 0
+          type: integer
+          format: int32
   securitySchemes:
-    bearerAuth:
+    Authorization:
       type: http
+      name: Authorization
       scheme: bearer
       bearerFormat: JWT
-security:
-  - bearerAuth: []


### PR DESCRIPTION
## 📝 작업 내용
- `@RequestParts` 사용시 각각의 content type을 지정해줘야 하는데, swagger에서 문서화 - 테스트 했을때 아래 에러가 나타남
```
HttpMediaTypeNotSupportedException: Content type 'application/octet-stream' not supported
``` 
- swagger에서 각 필드별로 content-type이 지정되지 않아 발생하는 문제.
```java
// AbstractMessageConverterMethodArgumentResolver.java
        if (contentType == null) {
            noContentType = true;
            contentType = MediaType.APPLICATION_OCTET_STREAM;
        } // content-type이 null일경우 application/octet-stream으로 설정한다.
```
- application/octet-stream을 처리해주는 컨버터 추가
- store, product 등록 API 문서화 추가
- product 수정, 조회, 삭제 API 문서화 추가

## 💬 ETC.
### 이미지 첨부하는 api swagger 결과물
<img width="1200" alt="image" src="https://github.com/backtothefuture-team/backtothefuture-backend/assets/67352902/8084c905-4920-4944-8564-3760f529a530">
<img width="1224" alt="image" src="https://github.com/backtothefuture-team/backtothefuture-backend/assets/67352902/92c51a7b-ef60-41fe-905f-9a7b37ccba0a">

### 추가한 API 문서 
<img width="1248" alt="image" src="https://github.com/backtothefuture-team/backtothefuture-backend/assets/67352902/47a56acc-18af-4939-9aee-5f6c9bc6dcf5">


## #️⃣ 연관된 이슈
resolves: #134