### PR TITLE
RestAssured 환경 설정

### DIFF
--- a/api/store/src/test/java/com/backtothefuture/global/RestAssuredTest.java
+++ b/api/store/src/test/java/com/backtothefuture/global/RestAssuredTest.java
@@ -1,0 +1,23 @@
+package com.backtothefuture.global;
+
+
+import com.backtothefuture.infra.config.BfTestConfig;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.jdbc.Sql;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Sql("classpath:reset.sql")
+public class RestAssuredTest extends BfTestConfig {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+}

--- a/api/store/src/test/resources/reset.sql
+++ b/api/store/src/test/resources/reset.sql
@@ -1,0 +1,7 @@
+SET foreign_key_checks=0;
+
+TRUNCATE TABLE member;
+
+TRUNCATE TABLE store;
+
+TRUNCATE TABLE product;

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ subprojects {
 		annotationProcessor "org.projectlombok:lombok"
 		testAnnotationProcessor "org.projectlombok:lombok"
 
+		testImplementation 'io.rest-assured:rest-assured'
 		testImplementation "org.springframework.boot:spring-boot-starter-test"
 		testImplementation 'org.springframework.security:spring-security-test'
 		testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'

--- a/core/infra/src/main/resources/application-infra.yml
+++ b/core/infra/src/main/resources/application-infra.yml
@@ -29,8 +29,8 @@ cloud:
   aws:
     s3:
       region: ${COULD_AWS_S3_REGION}
-      accesskey: ${CLOUD_AWS_S3_ACCESSKEY}
-      secretkey: ${CLOUD_AWS_S3_SECRETKEY}
+      accessKey: ${CLOUD_AWS_S3_ACCESSKEY}
+      secretKey: ${CLOUD_AWS_S3_SECRETKEY}
 
 logging:
   level:


### PR DESCRIPTION
## 📝 작업 내용
- RestAssured 환경설정했습니다.

## 💬 ETC.
- RestAssured 설정 후 임시로 테스트 코드를 돌려보니, s3 관련 설정 값이 바인딩이 안되는 이슈가 있었습니다.
  - 유선님이 말씀주신 것처럼 yml 파일에 카멜케이스를 수정하니 이슈가 해결되었습니다.
- 테스트 모듈에 있는 클래스 파일은 모듈 간 참조가 안되어 store외에 모듈에서 RestAssured 테스트를 진행하고 싶으면 `RestAssuredTest.java`와 똑같이 파일을 생성해서 사용하면 됩니다.
- 사용 방법은 아래와 같이 이전에 테스트 실행 시 `BfTestConfig` 상속 받았던 것처럼 RestAssured를 상속받으면 됩니다.
![](https://github.com/backtothefuture-team/backtothefuture-backend/assets/108214590/9f7ab850-15c7-48ba-9d33-c6822a4846bd)
- 각 테스트 메서드 간 멱등성을 보장하기 위해 테스트 메서드 실행 후 모든 테이블을 truncate하는 SQL을 실행하도록 설정했습니다.

## #️⃣ 연관된 이슈
#115 