### PR TITLE
리뷰 CRUD API 구현

### DIFF
--- a/api/store/src/main/java/com/backtothefuture/store/controller/ReviewController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/ReviewController.java
@@ -20,15 +20,18 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+
+@RequestMapping("/reviews")
 @RestController
 @RequiredArgsConstructor
 public class ReviewController {
 
     private final ReviewService reviewService;
 
-    @PostMapping("/reviews")
+    @PostMapping("")
     public ResponseEntity<BfResponse<Void>> createReview(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @Valid @ModelAttribute ReviewCreateRequest request
@@ -38,7 +41,7 @@ public class ReviewController {
                 .build();
     }
 
-    @GetMapping("/reviews")
+    @GetMapping("")
     public ResponseEntity<BfResponse<List<ReviewsReadResponse>>> readReviews(
             @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
@@ -49,7 +52,7 @@ public class ReviewController {
         );
     }
 
-    @PatchMapping("/reviews")
+    @PatchMapping("")
     public ResponseEntity<BfResponse<Void>> updateReview(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @Valid @ModelAttribute ReviewUpdateRequest request
@@ -59,7 +62,7 @@ public class ReviewController {
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/reviews/{reviewId}")
+    @DeleteMapping("/{reviewId}")
     public ResponseEntity<BfResponse<Void>> deleteReview(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable Long reviewId

--- a/api/store/src/main/java/com/backtothefuture/store/controller/ReviewController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/ReviewController.java
@@ -1,0 +1,31 @@
+package com.backtothefuture.store.controller;
+
+import com.backtothefuture.domain.response.BfResponse;
+import com.backtothefuture.security.service.UserDetailsImpl;
+import com.backtothefuture.store.dto.request.ReviewCreateRequest;
+import com.backtothefuture.store.service.ReviewService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @PostMapping("/reviews")
+    public ResponseEntity<BfResponse<Void>> createReview(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Valid @ModelAttribute ReviewCreateRequest request
+    ) {
+        reviewService.save(userDetails.getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .build();
+    }
+}

--- a/api/store/src/main/java/com/backtothefuture/store/controller/ReviewController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/ReviewController.java
@@ -14,9 +14,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -53,6 +55,16 @@ public class ReviewController {
             @Valid @ModelAttribute ReviewUpdateRequest request
     ) {
         reviewService.update(userDetails.getId(), request);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/reviews/{reviewId}")
+    public ResponseEntity<BfResponse<Void>> deleteReview(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long reviewId
+    ) {
+        reviewService.delete(userDetails.getId(), reviewId);
 
         return ResponseEntity.ok().build();
     }

--- a/api/store/src/main/java/com/backtothefuture/store/controller/ReviewController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/ReviewController.java
@@ -5,6 +5,7 @@ import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.SUCCESS;
 import com.backtothefuture.domain.response.BfResponse;
 import com.backtothefuture.security.service.UserDetailsImpl;
 import com.backtothefuture.store.dto.request.ReviewCreateRequest;
+import com.backtothefuture.store.dto.request.ReviewUpdateRequest;
 import com.backtothefuture.store.dto.response.ReviewsReadResponse;
 import com.backtothefuture.store.service.ReviewService;
 import jakarta.validation.Valid;
@@ -15,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -43,5 +45,15 @@ public class ReviewController {
         return ResponseEntity.ok(
                 new BfResponse<>(SUCCESS, response)
         );
+    }
+
+    @PatchMapping("/reviews")
+    public ResponseEntity<BfResponse<Void>> updateReview(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Valid @ModelAttribute ReviewUpdateRequest request
+    ) {
+        reviewService.update(userDetails.getId(), request);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/api/store/src/main/java/com/backtothefuture/store/controller/ReviewController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/ReviewController.java
@@ -1,14 +1,19 @@
 package com.backtothefuture.store.controller;
 
+import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.SUCCESS;
+
 import com.backtothefuture.domain.response.BfResponse;
 import com.backtothefuture.security.service.UserDetailsImpl;
 import com.backtothefuture.store.dto.request.ReviewCreateRequest;
+import com.backtothefuture.store.dto.response.ReviewsReadResponse;
 import com.backtothefuture.store.service.ReviewService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,5 +32,16 @@ public class ReviewController {
         reviewService.save(userDetails.getId(), request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .build();
+    }
+
+    @GetMapping("/reviews")
+    public ResponseEntity<BfResponse<List<ReviewsReadResponse>>> readReviews(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        List<ReviewsReadResponse> response = reviewService.findAllBy(userDetails.getId());
+
+        return ResponseEntity.ok(
+                new BfResponse<>(SUCCESS, response)
+        );
     }
 }

--- a/api/store/src/main/java/com/backtothefuture/store/dto/request/ReviewCreateRequest.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/request/ReviewCreateRequest.java
@@ -1,0 +1,27 @@
+package com.backtothefuture.store.dto.request;
+
+import com.backtothefuture.domain.review.Review;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
+
+public record ReviewCreateRequest(
+        @NotNull
+        Long storeId,
+
+        @NotNull
+        int ratingCount, // TODO 더블로 수정
+
+        String content,
+        MultipartFile imageFile
+        // TODO 예약상품 id
+
+) {
+    public Review toEntity(Long memberId) {
+        return Review.builder()
+                .memberId(memberId)
+                .storeId(storeId)
+                .ratingCount(ratingCount)
+                .content(content)
+                .build();
+    }
+}

--- a/api/store/src/main/java/com/backtothefuture/store/dto/request/ReviewCreateRequest.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/request/ReviewCreateRequest.java
@@ -5,10 +5,10 @@ import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
 
 public record ReviewCreateRequest(
-        @NotNull
+        @NotNull(message = "상점ID는 필수 값입니다.")
         Long storeId,
 
-        @NotNull
+        @NotNull(message = "별점은 필수 값입니다.")
         Double ratingCount,
 
         String content,

--- a/api/store/src/main/java/com/backtothefuture/store/dto/request/ReviewCreateRequest.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/request/ReviewCreateRequest.java
@@ -9,7 +9,7 @@ public record ReviewCreateRequest(
         Long storeId,
 
         @NotNull
-        int ratingCount, // TODO 더블로 수정
+        Double ratingCount,
 
         String content,
         MultipartFile imageFile

--- a/api/store/src/main/java/com/backtothefuture/store/dto/request/ReviewUpdateRequest.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/request/ReviewUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.backtothefuture.store.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
+
+public record ReviewUpdateRequest(
+        @NotNull
+        Long reviewId,
+
+        Double ratingCount,
+        String content,
+        MultipartFile imageFile
+) {
+}

--- a/api/store/src/main/java/com/backtothefuture/store/dto/request/ReviewUpdateRequest.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/request/ReviewUpdateRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
 
 public record ReviewUpdateRequest(
-        @NotNull
+        @NotNull(message = "리뷰 식별자는 필수 값입니다.")
         Long reviewId,
 
         Double ratingCount,

--- a/api/store/src/main/java/com/backtothefuture/store/dto/response/ReviewsReadResponse.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/response/ReviewsReadResponse.java
@@ -1,0 +1,32 @@
+package com.backtothefuture.store.dto.response;
+
+import com.backtothefuture.domain.review.Review;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ReviewsReadResponse(
+        Long id,
+        String storeName,
+        Double ratingCount,
+        LocalDateTime createdAt,
+        String imageUrl,
+        String content
+) {
+
+    public static List<ReviewsReadResponse> from(List<Review> reviews) {
+        return reviews.stream()
+                .map(ReviewsReadResponse::from)
+                .toList();
+    }
+
+    private static ReviewsReadResponse from(Review review) {
+        return new ReviewsReadResponse(
+                review.getId(),
+                review.getStore().getName(),
+                review.getRatingCount(),
+                review.getCreatedAt(),
+                review.getImageUrl(),
+                review.getContent()
+        );
+    }
+}

--- a/api/store/src/main/java/com/backtothefuture/store/exception/ReviewException.java
+++ b/api/store/src/main/java/com/backtothefuture/store/exception/ReviewException.java
@@ -1,0 +1,14 @@
+package com.backtothefuture.store.exception;
+
+import com.backtothefuture.domain.common.enums.ReviewErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ReviewException extends RuntimeException {
+    private final ReviewErrorCode errorCode;
+
+    public ReviewException(ReviewErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/api/store/src/main/java/com/backtothefuture/store/service/ReviewService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/ReviewService.java
@@ -5,9 +5,13 @@ import com.backtothefuture.domain.common.util.s3.S3Util;
 import com.backtothefuture.domain.review.Review;
 import com.backtothefuture.domain.review.repository.ReviewRepository;
 import com.backtothefuture.store.dto.request.ReviewCreateRequest;
+import com.backtothefuture.store.dto.response.ReviewsReadResponse;
 import com.backtothefuture.store.exception.ReviewException;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -53,5 +57,11 @@ public class ReviewService {
         } catch (IOException e) {
             throw new ReviewException(ReviewErrorCode.IMAGE_UPLOAD_FAIL);
         }
+    }
+
+    public List<ReviewsReadResponse> findAllBy(Long memberId) {
+        List<Review> reviews = reviewRepository.findAllByMemberId(memberId, Sort.by(Direction.DESC, "createdAt"));
+
+        return ReviewsReadResponse.from(reviews);
     }
 }

--- a/api/store/src/main/java/com/backtothefuture/store/service/ReviewService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/ReviewService.java
@@ -81,6 +81,14 @@ public class ReviewService {
         }
     }
 
+    @Transactional
+    public void delete(Long memberId, Long reviewId) {
+        Review review = findById(reviewId);
+        validateMemberMatch(review, memberId);
+
+        reviewRepository.deleteById(reviewId);
+    }
+
     private void validateMemberMatch(Review review, Long memberId) {
         if (!Objects.equals(review.getMemberId(), memberId)) {
             throw new ReviewException(ReviewErrorCode.MEMBER_MISMATCH);

--- a/api/store/src/main/java/com/backtothefuture/store/service/ReviewService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/ReviewService.java
@@ -1,0 +1,57 @@
+package com.backtothefuture.store.service;
+
+import com.backtothefuture.domain.common.enums.ReviewErrorCode;
+import com.backtothefuture.domain.common.util.s3.S3Util;
+import com.backtothefuture.domain.review.Review;
+import com.backtothefuture.domain.review.repository.ReviewRepository;
+import com.backtothefuture.store.dto.request.ReviewCreateRequest;
+import com.backtothefuture.store.exception.ReviewException;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final S3Util s3Util;
+
+    @Transactional
+    public void save(Long memberId, ReviewCreateRequest request) {
+        validateCreatable();
+
+        Review review = request.toEntity(memberId);
+        reviewRepository.save(review);
+
+        String imageUrl = uploadReviewImage(review.getId(), request.imageFile());
+        review.updateImageUrl(imageUrl);
+    }
+
+    private void validateCreatable() {
+        boolean outOfDate = false; // TODO: 3일 이내에 결제한 리뷰인지 검증
+        if (outOfDate) {
+            throw new ReviewException(ReviewErrorCode.OUT_OF_DATE);
+        }
+
+        boolean exists = false; // TODO 이미 작성한 리뷰인지 검증
+        if (exists) {
+            throw new ReviewException(ReviewErrorCode.ALREADY_EXISTS);
+        }
+    }
+
+    private String uploadReviewImage(Long reviewId, MultipartFile multipartFile) {
+        try {
+           return s3Util.uploadReviewImage(reviewId.toString(), multipartFile);
+
+        } catch (IllegalArgumentException e) {
+            throw new ReviewException(ReviewErrorCode.UNSUPPORTED_IMAGE_EXTENSION);
+
+        } catch (IOException e) {
+            throw new ReviewException(ReviewErrorCode.IMAGE_UPLOAD_FAIL);
+        }
+    }
+}

--- a/api/store/src/main/java/com/backtothefuture/store/service/ReviewService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/ReviewService.java
@@ -86,6 +86,8 @@ public class ReviewService {
         Review review = findById(reviewId);
         validateMemberMatch(review, memberId);
 
+        s3Util.deletePastReviewImage(reviewId.toString());
+
         reviewRepository.deleteById(reviewId);
     }
 

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/BaseEntity.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/BaseEntity.java
@@ -1,15 +1,15 @@
 package com.backtothefuture.domain.common;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
-
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
-
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/enums/ReviewErrorCode.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/enums/ReviewErrorCode.java
@@ -10,6 +10,10 @@ public enum ReviewErrorCode implements BaseErrorCode {
     OUT_OF_DATE(400, "픽업일로부터 3일 이내에만 리뷰 작성이 가능합니다.", HttpStatus.BAD_REQUEST),
     ALREADY_EXISTS(400, "이미 작성한 리뷰입니다.", HttpStatus.BAD_REQUEST),
     UNSUPPORTED_IMAGE_EXTENSION(400, "지원하지 않는 확장자 입니다. jpeg혹은 png 파일을 업로드 해주세요.", HttpStatus.BAD_REQUEST),
+    NOT_EXISTS(400, "존재하지 않는 리뷰입니다.", HttpStatus.BAD_REQUEST),
+
+    // 401
+    MEMBER_MISMATCH(401, "수정/삭제 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
 
     // 500
     IMAGE_UPLOAD_FAIL(500, "이미지 업로드에 실패했습니다. 관리자에게 문의해 주세요.", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/enums/ReviewErrorCode.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/enums/ReviewErrorCode.java
@@ -1,0 +1,31 @@
+package com.backtothefuture.domain.common.enums;
+
+import com.backtothefuture.domain.response.ErrorResponse;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ReviewErrorCode implements BaseErrorCode {
+    // 400
+    OUT_OF_DATE(400, "픽업일로부터 3일 이내에만 리뷰 작성이 가능합니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_EXISTS(400, "이미 작성한 리뷰입니다.", HttpStatus.BAD_REQUEST),
+    UNSUPPORTED_IMAGE_EXTENSION(400, "지원하지 않는 확장자 입니다. jpeg혹은 png 파일을 업로드 해주세요.", HttpStatus.BAD_REQUEST),
+
+    // 500
+    IMAGE_UPLOAD_FAIL(500, "이미지 업로드에 실패했습니다. 관리자에게 문의해 주세요.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final int errorCode;
+    private final String errorMessage;
+    private final HttpStatus status;
+
+    ReviewErrorCode(int errorCode, String message, HttpStatus status) {
+        this.errorCode = errorCode;
+        this.errorMessage = message;
+        this.status = status;
+    }
+
+    @Override
+    public ErrorResponse getErrorResponse() {
+        return new ErrorResponse(this.errorCode, this.errorMessage);
+    }
+}

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/util/s3/S3Util.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/util/s3/S3Util.java
@@ -120,6 +120,12 @@ public class S3Util {
         return uploadImageToS3AndDeletePast(imageBucketName, key, file, dirPath);
     }
 
+    public void deletePastReviewImage(String reviewId) {
+        String dirPath = String.join("/", List.of("review", reviewId, ""));
+
+        s3AsyncUtil.deletePastImages(dirPath);
+    }
+
     public String getCurrentTimestamp() {
         Timestamp timestamp = new Timestamp(System.currentTimeMillis());
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMddhhmmss");

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/util/s3/S3Util.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/util/s3/S3Util.java
@@ -112,6 +112,14 @@ public class S3Util {
         return uploadImageToS3AndDeletePast(imageBucketName, key, file, dirPath);
     }
 
+    public String uploadReviewImage(String reviewId, MultipartFile file) throws IOException {
+        String dirPath = String.join("/", List.of("review", reviewId, ""));
+
+        String key = dirPath + getCurrentTimestamp() + "." + getImageExtension(file);
+
+        return uploadImageToS3AndDeletePast(imageBucketName, key, file, dirPath);
+    }
+
     public String getCurrentTimestamp() {
         Timestamp timestamp = new Timestamp(System.currentTimeMillis());
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMddhhmmss");

--- a/core/domain/src/main/java/com/backtothefuture/domain/review/Review.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/review/Review.java
@@ -1,0 +1,48 @@
+package com.backtothefuture.domain.review;
+
+import com.backtothefuture.domain.common.MutableBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review extends MutableBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
+    private Long id;
+
+    private Long memberId;
+    private Long storeId;
+    // TODO 예약상품id
+
+    private int ratingCount;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private String imageUrl;
+
+    @Builder
+    private Review(Long memberId, Long storeId, int ratingCount, String content) {
+        this.memberId = memberId;
+        this.storeId = storeId;
+        this.ratingCount = ratingCount;
+        this.content = content;
+    }
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+}

--- a/core/domain/src/main/java/com/backtothefuture/domain/review/Review.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/review/Review.java
@@ -1,12 +1,16 @@
 package com.backtothefuture.domain.review;
 
 import com.backtothefuture.domain.common.MutableBaseEntity;
+import com.backtothefuture.domain.store.Store;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,11 +26,18 @@ public class Review extends MutableBaseEntity {
     @Column(name = "review_id")
     private Long id;
 
-    private Long memberId;
+    @ManyToOne(fetch = FetchType.LAZY) //
+    @JoinColumn(name = "store_id", insertable = false, updatable = false)
+    private Store store;
+
+    @Column(name = "store_id")
     private Long storeId;
+
+    private Long memberId;
+
     // TODO 예약상품id
 
-    private int ratingCount;
+    private Double ratingCount;
 
     @Lob
     @Column(columnDefinition = "TEXT")
@@ -35,7 +46,7 @@ public class Review extends MutableBaseEntity {
     private String imageUrl;
 
     @Builder
-    private Review(Long memberId, Long storeId, int ratingCount, String content) {
+    private Review(Long memberId, Long storeId, Double ratingCount, String content) {
         this.memberId = memberId;
         this.storeId = storeId;
         this.ratingCount = ratingCount;

--- a/core/domain/src/main/java/com/backtothefuture/domain/review/Review.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/review/Review.java
@@ -15,10 +15,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
 public class Review extends MutableBaseEntity {
 
     @Id
@@ -54,6 +56,17 @@ public class Review extends MutableBaseEntity {
     }
 
     public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public void update(Double ratingCount, String content) {
+        this.ratingCount = ratingCount;
+        this.content = content;
+    }
+
+    public void update(Double ratingCount, String content, String imageUrl) {
+        this.ratingCount = ratingCount;
+        this.content = content;
         this.imageUrl = imageUrl;
     }
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/review/Review.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/review/Review.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +22,8 @@ import org.hibernate.annotations.DynamicUpdate;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicUpdate
+@Builder
+@AllArgsConstructor
 public class Review extends MutableBaseEntity {
 
     @Id
@@ -46,14 +49,6 @@ public class Review extends MutableBaseEntity {
     private String content;
 
     private String imageUrl;
-
-    @Builder
-    private Review(Long memberId, Long storeId, Double ratingCount, String content) {
-        this.memberId = memberId;
-        this.storeId = storeId;
-        this.ratingCount = ratingCount;
-        this.content = content;
-    }
 
     public void updateImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;

--- a/core/domain/src/main/java/com/backtothefuture/domain/review/repository/ReviewRepository.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/review/repository/ReviewRepository.java
@@ -1,7 +1,11 @@
 package com.backtothefuture.domain.review.repository;
 
 import com.backtothefuture.domain.review.Review;
+import java.util.List;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    List<Review> findAllByMemberId(Long memberId, Sort sort);
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/review/repository/ReviewRepository.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.backtothefuture.domain.review.repository;
+
+import com.backtothefuture.domain.review.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/core/domain/src/main/java/com/backtothefuture/domain/store/Store.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/store/Store.java
@@ -2,7 +2,6 @@ package com.backtothefuture.domain.store;
 
 import com.backtothefuture.domain.common.MutableBaseEntity;
 import com.backtothefuture.domain.member.Member;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,13 +11,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -47,6 +45,10 @@ public class Store extends MutableBaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;        // 회원
+
+    private double rating; // TODO 리뷰가 등록될 때 rating, ratingCount가 업데이트되어야 함
+
+    private double ratingCount;
 
     private LocalTime startTime; // 영업 시작 시간
 

--- a/core/infra/src/testFixtures/resources/init.sql
+++ b/core/infra/src/testFixtures/resources/init.sql
@@ -110,13 +110,17 @@ CREATE TABLE reservation_status_history
 
 CREATE TABLE IF NOT EXISTS review
 (
-    review_id VARCHAR(255) NOT NULL,
-    member_id VARCHAR(255) NOT NULL,
-    store_id  VARCHAR(255) NOT NULL,
-    star      VARCHAR(255) NULL,
-    content   VARCHAR(255) NULL
-
-);
+    review_id       BIGINT     NOT NULL    AUTO_INCREMENT PRIMARY KEY,
+    member_id       BIGINT     NOT NULL,
+    store_id        BIGINT     NOT NULL,
+    rating_count    DOUBLE     NOT NULL,
+    content         TEXT,
+    image_url       VARCHAR(255),
+    updated_at      datetime(6),
+    updated_by      varchar(255),
+    created_at      datetime(6),
+    created_by      varchar(255)
+)
 
 INSERT INTO member (member_id, auth_id, email, name, password, phone_number, status, provider, roles, updated_at,
                     updated_by, created_at, created_by)

--- a/core/infra/src/testFixtures/resources/init.sql
+++ b/core/infra/src/testFixtures/resources/init.sql
@@ -35,7 +35,7 @@ CREATE TABLE store
     created_at   datetime(6),
     created_by   varchar(255),
     rating       double,
-    rating_count int,
+    rating_count double,
     start_time   time,
     end_time     time,
     FOREIGN KEY (member_id) REFERENCES member (member_id)

--- a/core/infra/src/testFixtures/resources/init.sql
+++ b/core/infra/src/testFixtures/resources/init.sql
@@ -120,7 +120,7 @@ CREATE TABLE IF NOT EXISTS review
     updated_by      varchar(255),
     created_at      datetime(6),
     created_by      varchar(255)
-)
+);
 
 INSERT INTO member (member_id, auth_id, email, name, password, phone_number, status, provider, roles, updated_at,
                     updated_by, created_at, created_by)

--- a/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
+++ b/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
@@ -147,7 +147,10 @@ public class SpringSecurityConfig {
                 antMatcher(DELETE, "/reservations/**"), // 주문 삭제
                 antMatcher(GET,"/reservations/done"), // 고객 주문 완료 내역
                 antMatcher(GET,"/reservations/proceeding"), // 고객 진행 중인 주문 내역
-                antMatcher(POST, "/reviews/**")
+
+                // Review
+                antMatcher(POST, "/reviews/**"),
+                antMatcher(GET, "/reviews/**")
         );
 
         return requestMatchers.toArray(RequestMatcher[]::new);

--- a/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
+++ b/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
@@ -146,9 +146,8 @@ public class SpringSecurityConfig {
                 antMatcher(POST, "/member/refresh"), // 엑세스 토큰 갱신
                 antMatcher(DELETE, "/reservations/**"), // 주문 삭제
                 antMatcher(GET,"/reservations/done"), // 고객 주문 완료 내역
-                antMatcher(GET,"/reservations/proceeding") // 고객 진행 중인 주문 내역
-
-
+                antMatcher(GET,"/reservations/proceeding"), // 고객 진행 중인 주문 내역
+                antMatcher(POST, "/reviews/**")
         );
 
         return requestMatchers.toArray(RequestMatcher[]::new);

--- a/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
+++ b/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
@@ -145,14 +145,15 @@ public class SpringSecurityConfig {
                 antMatcher(DELETE, "/reservations/**"), // 주문 삭제
                 antMatcher(POST, "/member/refresh"), // 엑세스 토큰 갱신
                 antMatcher(DELETE, "/reservations/**"), // 주문 삭제
-                antMatcher(GET,"/reservations/done"), // 고객 주문 완료 내역
-                antMatcher(GET,"/reservations/proceeding"), // 고객 진행 중인 주문 내역
+                antMatcher(GET, "/reservations/done"), // 고객 주문 완료 내역
+                antMatcher(GET, "/reservations/proceeding"), // 고객 진행 중인 주문 내역
 
                 // Review
                 antMatcher(POST, "/reviews/**"),
                 antMatcher(GET, "/reviews/**"),
-                antMatcher(PATCH, "/reviews/**")
-        );
+                antMatcher(PATCH, "/reviews/**"),
+                antMatcher(DELETE, "/reviews/**")
+                );
 
         return requestMatchers.toArray(RequestMatcher[]::new);
     }

--- a/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
+++ b/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
@@ -150,7 +150,8 @@ public class SpringSecurityConfig {
 
                 // Review
                 antMatcher(POST, "/reviews/**"),
-                antMatcher(GET, "/reviews/**")
+                antMatcher(GET, "/reviews/**"),
+                antMatcher(PATCH, "/reviews/**")
         );
 
         return requestMatchers.toArray(RequestMatcher[]::new);

--- a/initdb.d/init.sql
+++ b/initdb.d/init.sql
@@ -70,7 +70,7 @@ CREATE TABLE IF NOT EXISTS review
     updated_by      varchar(255),
     created_at      datetime(6),
     created_by      varchar(255)
-)
+);
 
 CREATE TABLE reservation
 (

--- a/initdb.d/init.sql
+++ b/initdb.d/init.sql
@@ -58,6 +58,20 @@ CREATE TABLE product
     FOREIGN KEY (store_id) REFERENCES store (store_id)
 );
 
+CREATE TABLE IF NOT EXISTS review
+(
+    review_id       BIGINT     NOT NULL    AUTO_INCREMENT PRIMARY KEY,
+    member_id       BIGINT     NOT NULL,
+    store_id        BIGINT     NOT NULL,
+    rating_count    DOUBLE     NOT NULL,
+    content         TEXT,
+    image_url       VARCHAR(255),
+    updated_at      datetime(6),
+    updated_by      varchar(255),
+    created_at      datetime(6),
+    created_by      varchar(255)
+)
+
 CREATE TABLE reservation
 (
     reservation_id   bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
## 📝 작업 내용
 - 리뷰 CRUD API 구현

## 💬 ETC.
 - 리뷰 작성/수정 시 구매일자 기준 3일 이내에만 가능합니다.
   -  현재까지 구현된 로직 기준 픽업 완료 일시를 확인할 수 없어서 TODO 로 주석 남겨 놓았습니다.
 - 유선님이 이슈에 댓글 남겨주신 부분 확인했습니다.
   - 사장님 댓글 작성 기능도 현재 미구현으로 우선 "사장님 댓글이 있을 시 삭제 불가"도 추후 구현할 예정입니다.
 - 상점 조회 시 리뷰를 활용해야 하는 부분이 있어서 해당 PR 머지되면 상점 조회 API 마무리 하겠습니다. 

## #️⃣ 연관된 이슈
resolves: #146