### PR TITLE
정렬 옵션없는 가게 목록 조회 API 구현

### DIFF
--- a/api/store/src/main/java/com/backtothefuture/store/controller/StoreController.java
+++ b/api/store/src/main/java/com/backtothefuture/store/controller/StoreController.java
@@ -1,10 +1,13 @@
 package com.backtothefuture.store.controller;
 
 import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.CREATE;
+import static com.backtothefuture.domain.common.enums.GlobalSuccessCode.SUCCESS;
 
 import com.backtothefuture.domain.response.BfResponse;
 import com.backtothefuture.security.service.UserDetailsImpl;
+import com.backtothefuture.store.domain.SortingOption;
 import com.backtothefuture.store.dto.request.StoreRegisterDto;
+import com.backtothefuture.store.dto.response.StoreResponse;
 import com.backtothefuture.store.service.StoreService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -14,14 +17,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -56,5 +62,32 @@ public class StoreController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new BfResponse<>(CREATE,
                         Map.of("store_id", storeService.registerStore(userDetails, storeRegisterDto, thumbnail))));
+    }
+
+    @Operation(
+            summary = "가게 조회 API",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "목록 조회 성공", useReturnTypeSchema = true)
+            },
+            parameters = {
+                    @Parameter(name = "sortingOption", description = "정렬 옵션(값이 없을 시 기본 default 적용)", example = "default/star/distance"),
+                    @Parameter(name = "cursor", description = "커서(값이 없을 시 기본 0 적용): 이전 페이지의 마지막 가게 식별자", example = "0"),
+                    @Parameter(name = "size", description = "페이지 크기(값이 없을 시 기본 10 적용)", example = "10")
+            }
+    )
+    @GetMapping("")
+    public ResponseEntity<BfResponse<?>> readStores(
+            @RequestParam(defaultValue = "default") String sortingOption,
+            @RequestParam(defaultValue = "0") Long cursor,
+            @RequestParam(defaultValue = "10") Integer size
+    ) {
+        List<StoreResponse> response = storeService.findStores(
+                SortingOption.from(sortingOption),
+                cursor,
+                size
+        );
+
+        return ResponseEntity.ok()
+                .body(new BfResponse<>(SUCCESS, response));
     }
 }

--- a/api/store/src/main/java/com/backtothefuture/store/domain/SortingOption.java
+++ b/api/store/src/main/java/com/backtothefuture/store/domain/SortingOption.java
@@ -1,0 +1,25 @@
+package com.backtothefuture.store.domain;
+
+import com.backtothefuture.domain.common.enums.StoreErrorCode;
+import com.backtothefuture.store.exception.StoreException;
+import java.util.Arrays;
+
+public enum SortingOption {
+
+    DEFAULT("default"),
+    STAR("star"),
+    DISTANCE("distance");
+
+    private final String text;
+
+    SortingOption(String text) {
+        this.text = text;
+    }
+
+    public static SortingOption from(String text) {
+        return Arrays.stream(SortingOption.values())
+                .filter(sortingOption -> sortingOption.text.equals(text))
+                .findAny()
+                .orElseThrow(() -> new StoreException(StoreErrorCode.INVALID_SORTING_OPTION));
+    }
+}

--- a/api/store/src/main/java/com/backtothefuture/store/dto/response/StoreResponse.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/response/StoreResponse.java
@@ -1,0 +1,35 @@
+package com.backtothefuture.store.dto.response;
+
+import com.backtothefuture.domain.store.Store;
+import java.time.LocalTime;
+
+public record StoreResponse(
+        Long id,
+        String name,
+        String image,
+
+        //int surpriseBagAmount,
+        //int surpriseBagPrice,
+        //int surpriseBagDiscountRate, // TODO 서프라이즈백 구분 기능 확정된 후 구현
+
+        double rating,
+        int ratingCount,
+
+        LocalTime startTime,
+        LocalTime endTime
+
+        // TODO 거리 표시
+) {
+
+    public static StoreResponse from(Store store) {
+        return new StoreResponse(
+                store.getId(),
+                store.getName(),
+                store.getImage(),
+                store.getRating(),
+                store.getRatingCount(),
+                store.getStartTime(),
+                store.getEndTime()
+        );
+    }
+}

--- a/api/store/src/main/java/com/backtothefuture/store/dto/response/StoreResponse.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/response/StoreResponse.java
@@ -12,8 +12,8 @@ public record StoreResponse(
         //int surpriseBagPrice,
         //int surpriseBagDiscountRate, // TODO 서프라이즈백 구분 기능 확정된 후 구현
 
-        double rating,
-        int ratingCount,
+        double averageRating,
+        int totalRatingCount,
 
         LocalTime startTime,
         LocalTime endTime
@@ -26,8 +26,8 @@ public record StoreResponse(
                 store.getId(),
                 store.getName(),
                 store.getImage(),
-                store.getRating(),
-                store.getRatingCount(),
+                store.getAverageRating(),
+                store.getTotalRatingCount(),
                 store.getStartTime(),
                 store.getEndTime()
         );

--- a/api/store/src/main/java/com/backtothefuture/store/service/StoreService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/StoreService.java
@@ -11,11 +11,16 @@ import com.backtothefuture.domain.member.repository.MemberRepository;
 import com.backtothefuture.domain.store.Store;
 import com.backtothefuture.domain.store.repository.StoreRepository;
 import com.backtothefuture.security.service.UserDetailsImpl;
+import com.backtothefuture.store.domain.SortingOption;
 import com.backtothefuture.store.dto.request.StoreRegisterDto;
+import com.backtothefuture.store.dto.response.StoreResponse;
 import com.backtothefuture.store.exception.StoreException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -57,7 +62,29 @@ public class StoreService {
                 throw new StoreException(IMAGE_UPLOAD_FAIL);
             }
         }
-        
+
         return id;
+    }
+
+    @Transactional(readOnly = true)
+    public List<StoreResponse> findStores(SortingOption sortingOption, Long cursor, Integer size) {
+        Pageable pageable = Pageable.ofSize(size);
+
+        List<Store> stores = new ArrayList<>();
+
+        switch (sortingOption) {
+            case DEFAULT:
+                stores = storeRepository.findStoresBy(cursor, pageable);
+
+            case STAR:
+                // TODO: 별점순으로 정렬하는 기능
+
+            case DISTANCE:
+                // TODO: 거리순으로 정렬하는 기능
+        }
+
+        return stores.stream()
+                .map(StoreResponse::from)
+                .toList();
     }
 }

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/enums/StoreErrorCode.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/enums/StoreErrorCode.java
@@ -1,18 +1,23 @@
 package com.backtothefuture.domain.common.enums;
 
-import org.springframework.http.HttpStatus;
-
 import com.backtothefuture.domain.response.ErrorResponse;
-
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public enum StoreErrorCode implements BaseErrorCode {
+
+    // 400
     CHECK_MEMBER(400, "회원의 정보를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
     DUPLICATED_STORE_NAME(400, "이미 존재하는 가게입니다.", HttpStatus.BAD_REQUEST),
     DUPLICATED_HEART(400, "이미 찜한 상점입니다.", HttpStatus.BAD_REQUEST),
-    NOT_FOUND_STORE_ID(404, "가게가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     UNSUPPORTED_IMAGE_EXTENSION(400, "지원하지 않는 확장자 입니다. jpeg혹은 png 파일을 업로드 해주세요.", HttpStatus.BAD_REQUEST),
+    INVALID_SORTING_OPTION(400, "잘못된 정렬 옵션입니다.", HttpStatus.BAD_REQUEST),
+
+    // 404
+    NOT_FOUND_STORE_ID(404, "가게가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+
+    // 500
     IMAGE_UPLOAD_FAIL(500, "이미지 업로드에 실패했습니다. 관리자에게 문의해 주세요.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final int errorCode;

--- a/core/domain/src/main/java/com/backtothefuture/domain/store/Store.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/store/Store.java
@@ -46,9 +46,9 @@ public class Store extends MutableBaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;        // 회원
 
-    private double rating; // TODO 리뷰가 등록될 때 rating, ratingCount가 업데이트되어야 함
+    private double averageRating; // TODO 리뷰가 등록될 때 rating, ratingCount가 업데이트되어야 함
 
-    private int ratingCount;
+    private int totalRatingCount;
 
     private LocalTime startTime; // 영업 시작 시간
 

--- a/core/domain/src/main/java/com/backtothefuture/domain/store/Store.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/store/Store.java
@@ -48,7 +48,7 @@ public class Store extends MutableBaseEntity {
 
     private double rating; // TODO 리뷰가 등록될 때 rating, ratingCount가 업데이트되어야 함
 
-    private double ratingCount;
+    private int ratingCount;
 
     private LocalTime startTime; // 영업 시작 시간
 

--- a/core/domain/src/main/java/com/backtothefuture/domain/store/repository/StoreRepository.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/store/repository/StoreRepository.java
@@ -1,13 +1,24 @@
 package com.backtothefuture.domain.store.repository;
 
 import com.backtothefuture.domain.store.Store;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
-	Optional<Store> findById(Long id);
+    Optional<Store> findById(Long id);
 
-	boolean existsByName(String name);
+    @Query("SELECT store FROM Store store "
+            + "WHERE (:cursor = 0L OR store.id < :cursor) "
+            + "ORDER BY store.id DESC")
+    List<Store> findStoresBy(
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+
+    boolean existsByName(String name);
 }

--- a/core/infra/src/testFixtures/resources/init.sql
+++ b/core/infra/src/testFixtures/resources/init.sql
@@ -23,21 +23,21 @@ CREATE TABLE member
 
 CREATE TABLE store
 (
-    store_id     bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    name         varchar(255),
-    description  TEXT,
-    location     varchar(255),
-    contact      varchar(255),
-    image        varchar(255),
-    member_id    bigint NOT NULL,
-    updated_at   datetime(6),
-    updated_by   varchar(255),
-    created_at   datetime(6),
-    created_by   varchar(255),
-    rating       double,
-    rating_count int,
-    start_time   time,
-    end_time     time,
+    store_id            bigint          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name                varchar(255),
+    description         TEXT,
+    location            varchar(255),
+    contact             varchar(255),
+    image               varchar(255),
+    member_id           bigint NOT NULL,
+    updated_at          datetime(6),
+    updated_by          varchar(255),
+    created_at          datetime(6),
+    created_by          varchar(255),
+    average_rating      double,
+    total_rating_count  int,
+    start_time          time,
+    end_time            time,
     FOREIGN KEY (member_id) REFERENCES member (member_id)
 );
 

--- a/core/infra/src/testFixtures/resources/init.sql
+++ b/core/infra/src/testFixtures/resources/init.sql
@@ -35,7 +35,7 @@ CREATE TABLE store
     created_at   datetime(6),
     created_by   varchar(255),
     rating       double,
-    rating_count double,
+    rating_count int,
     start_time   time,
     end_time     time,
     FOREIGN KEY (member_id) REFERENCES member (member_id)

--- a/initdb.d/init.sql
+++ b/initdb.d/init.sql
@@ -107,9 +107,28 @@ VALUES (1, null, 'email@naver.com', '이상민', 'mmsc532mmmm', '010-0000-0000',
         null,
         null, null);
 
-INSERT INTO store (store_id, name, description, location, contact, image, member_id, updated_at, updated_by, created_at,
-                   created_by, start_time, end_time)
-VALUES (1, 'test', 'test', null, null, null, 1, null, null, null, null, '10:00', '21:00');
+INSERT INTO store (name, description, location, contact, image, member_id, updated_at, updated_by, created_at, created_by, rating, rating_count, start_time, end_time)
+VALUES
+('상점1', '상점1 - 설명', 'Location 1', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '09:00:00', '18:00:00'),
+('상점2', '상점2 - 설명', 'Location 2', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '10:00:00', '19:00:00'),
+('상점3', '상점3 - 설명', 'Location 3', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '08:00:00', '17:00:00'),
+('상점4', '상점4 - 설명', 'Location 4', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '09:30:00', '18:30:00'),
+('상점5', '상점5 - 설명', 'Location 5', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '10:30:00', '19:30:00'),
+('상점6', '상점6 - 설명', 'Location 6', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '08:30:00', '17:30:00'),
+('상점7', '상점7 - 설명', 'Location 7', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '09:00:00', '18:00:00'),
+('상점8', '상점8 - 설명', 'Location 8', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '10:00:00', '19:00:00'),
+('상점9', '상점9 - 설명', 'Location 9', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '08:00:00', '17:00:00'),
+('상점10', '상점10 - 설명', 'Location 10', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '09:30:00', '18:30:00'),
+('상점11', '상점11 - 설명', 'Location 11', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '10:30:00', '19:30:00'),
+('상점12', '상점12 - 설명', 'Location 12', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '08:30:00', '17:30:00'),
+('상점13', '상점13 - 설명', 'Location 13', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '09:00:00', '18:00:00'),
+('상점14', '상점14 - 설명', 'Location 14', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '10:00:00', '19:00:00'),
+('상점15', '상점15 - 설명', 'Location 15', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '08:00:00', '17:00:00'),
+('상점16', '상점16 - 설명', 'Location 16', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '09:30:00', '18:30:00'),
+('상점17', '상점17 - 설명', 'Location 17', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '10:30:00', '19:30:00'),
+('상점18', '상점18 - 설명', 'Location 18', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '08:30:00', '17:30:00'),
+('상점19', '상점19 - 설명', 'Location 19', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '09:00:00', '18:00:00'),
+('상점20', '상점20 - 설명', 'Location 20', '010-1234-1234', 'https://bagtothefuture-static-image.s3.ap-northeast-2.amazonaws.com/review/4/20240502014849.', 1, NULL, NULL, NULL, NULL, 5, 10, '10:00:00', '19:00:00');
 
 INSERT INTO product (product_id, name, description, price, stock_quantity, thumbnail, store_id, updated_at, updated_by,
                      created_at, created_by)

--- a/initdb.d/init.sql
+++ b/initdb.d/init.sql
@@ -26,21 +26,21 @@ CREATE TABLE member
 
 CREATE TABLE store
 (
-    store_id     bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    name         varchar(255),
-    description  TEXT,
-    location     varchar(255),
-    contact      varchar(255),
-    image        varchar(255),
-    member_id    bigint NOT NULL,
-    updated_at   datetime(6),
-    updated_by   varchar(255),
-    created_at   datetime(6),
-    created_by   varchar(255),
-    rating       double,
-    rating_count int,
-    start_time   time,
-    end_time     time,
+    store_id            bigint          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name                varchar(255),
+    description         TEXT,
+    location            varchar(255),
+    contact             varchar(255),
+    image               varchar(255),
+    member_id           bigint NOT NULL,
+    updated_at          datetime(6),
+    updated_by          varchar(255),
+    created_at          datetime(6),
+    created_by          varchar(255),
+    average_rating      double,
+    total_rating_count  int,
+    start_time          time,
+    end_time            time,
     FOREIGN KEY (member_id) REFERENCES member (member_id)
 );
 

--- a/initdb.d/init.sql
+++ b/initdb.d/init.sql
@@ -26,19 +26,21 @@ CREATE TABLE member
 
 CREATE TABLE store
 (
-    store_id    bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    name        varchar(255),
-    description TEXT,
-    location    varchar(255),
-    contact     varchar(255),
-    image       varchar(255),
-    member_id   bigint NOT NULL,
-    updated_at  datetime(6),
-    updated_by  varchar(255),
-    created_at  datetime(6),
-    created_by  varchar(255),
-    start_time  time,
-    end_time    time,
+    store_id     bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name         varchar(255),
+    description  TEXT,
+    location     varchar(255),
+    contact      varchar(255),
+    image        varchar(255),
+    member_id    bigint NOT NULL,
+    updated_at   datetime(6),
+    updated_by   varchar(255),
+    created_at   datetime(6),
+    created_by   varchar(255),
+    rating       double,
+    rating_count int,
+    start_time   time,
+    end_time     time,
     FOREIGN KEY (member_id) REFERENCES member (member_id)
 );
 


### PR DESCRIPTION
## 📝 작업 내용
- 정렬 옵션없는 가게 목록 조회 API 구현했습니다.

## 💬 ETC.
- 별점/거리순 정렬 완료하고 가게 평점 업데이트하는 로직이 완성하겠습니다!

## #️⃣ 연관된 이슈
resolves: #148 