### PR TITLE
feat: 비밀번호 재설정 API 추가 #164

### DIFF
--- a/api/member/src/main/java/com/backtothefuture/member/controller/MemberController.java
+++ b/api/member/src/main/java/com/backtothefuture/member/controller/MemberController.java
@@ -212,7 +212,7 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
 
-    @PutMapping("/{memberId}/password")
+    @PatchMapping("/{memberId}/password")
     @Operation(summary = "비밀번호 재설정", description = "회원 비밀번호 재설정 API 입니다.", responses = {
             @ApiResponse(description = "비밀번호 변경 성공", responseCode = "200", content = @Content(schema = @Schema(implementation = BfResponse.class)))},
             parameters = {

--- a/api/member/src/main/java/com/backtothefuture/member/controller/MemberController.java
+++ b/api/member/src/main/java/com/backtothefuture/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.backtothefuture.domain.common.enums.OAuthErrorCode;
 import com.backtothefuture.domain.response.BfResponse;
 import com.backtothefuture.domain.response.ErrorResponse;
 import com.backtothefuture.member.dto.request.MemberLoginDto;
+import com.backtothefuture.member.dto.request.MemberPasswordResetRequestDto;
 import com.backtothefuture.member.dto.request.MemberRegisterDto;
 import com.backtothefuture.member.dto.request.MemberUpdateRequestDto;
 import com.backtothefuture.member.dto.request.OAuthLoginDto;
@@ -208,6 +209,21 @@ public class MemberController {
             @PathVariable("memberId") Long memberId
     ) {
         memberService.inactiveMember(userDetails, memberId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{memberId}/password")
+    @Operation(summary = "비밀번호 재설정", description = "회원 비밀번호 재설정 API 입니다.", responses = {
+            @ApiResponse(description = "비밀번호 변경 성공", responseCode = "200", content = @Content(schema = @Schema(implementation = BfResponse.class)))},
+            parameters = {
+                    @Parameter(name = "memberId", description = "회원 ID", required = true)
+            })
+    public ResponseEntity<BfResponse<?>> resetPassword(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable("memberId") Long memberId,
+            @Valid @RequestBody MemberPasswordResetRequestDto resetRequestDto
+    ) {
+        memberService.resetPassword(userDetails, memberId, resetRequestDto);
         return ResponseEntity.noContent().build();
     }
 

--- a/api/member/src/main/java/com/backtothefuture/member/dto/request/MemberPasswordResetRequestDto.java
+++ b/api/member/src/main/java/com/backtothefuture/member/dto/request/MemberPasswordResetRequestDto.java
@@ -1,0 +1,18 @@
+package com.backtothefuture.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "비밀번호 재설정 요청 정보(DTO)")
+public record MemberPasswordResetRequestDto(
+        @Schema(description = "새 비밀번호", example = "password9876!", required = true, minLength = 6)
+        @NotBlank(message = "새 비밀번호는 필수 항목입니다.")
+        @Size(min = 6, message = "비밀번호는 최소 6자 이상 입력해주세요.")
+        String newPassword,
+
+        @Schema(description = "새 비밀번호 확인", example = "password9876!", required = true)
+        @NotBlank(message = "새 비밀번호 확인은 필수 항목입니다.")
+        String newPasswordConfirm
+) {
+}

--- a/core/domain/src/main/java/com/backtothefuture/domain/common/enums/MemberErrorCode.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/common/enums/MemberErrorCode.java
@@ -19,6 +19,7 @@ public enum MemberErrorCode implements BaseErrorCode {
 
     // 403 FORBIDDEN
     FORBIDDEN_DELETE_MEMBER(403, "권한이 없습니다. 본인 계정만 탈퇴할 수 있습니다.", HttpStatus.FORBIDDEN),
+    FORBIDDEN_RESET_PASSWORD(403, "권한이 없습니다. 본인 계정만 비밀번호 변경이 가능합니다.", HttpStatus.FORBIDDEN),
 
     // 404 NOT_FOUND
     NOT_FOUND_MEMBER_ID(404, "존재하지 않는 회원입니다.", HttpStatus.NOT_FOUND),

--- a/core/domain/src/main/java/com/backtothefuture/domain/member/Member.java
+++ b/core/domain/src/main/java/com/backtothefuture/domain/member/Member.java
@@ -115,4 +115,8 @@ public class Member extends MutableBaseEntity {
     public void setRegistrationToken(String token) {
         this.registrationToken = token;
     }
+
+    public void resetPassword(String password) {
+        this.password = password;
+    }
 }

--- a/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
+++ b/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
@@ -137,8 +137,9 @@ public class SpringSecurityConfig {
      */
     private RequestMatcher[] AuthRequestMatchers() {
         List<RequestMatcher> requestMatchers = List.of(
+                antMatcher(GET, "/member/{memberId}"),                  // 회원 정보 조회
                 antMatcher(PATCH, "/member/{memberId}"),                // 회원 정보 수정
-                antMatcher(PUT, "/member/{memberId}/password"),        // 비밀번호 재설정
+                antMatcher(PATCH, "/member/{memberId}/password"),        // 비밀번호 재설정
                 antMatcher(DELETE, "/member/{memberId}"),                // 회원 탈퇴
                 antMatcher(POST, "/stores"),                            // 가게 등록
                 antMatcher(POST, "/stores/{storeId}/products"),                // 상품 등록

--- a/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
+++ b/core/security/src/main/java/com/backtothefuture/security/config/SpringSecurityConfig.java
@@ -8,6 +8,7 @@ import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.OPTIONS;
 import static org.springframework.http.HttpMethod.PATCH;
 import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
 import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
 
 import com.backtothefuture.security.exception.CustomAccessDeniedHandler;
@@ -137,6 +138,7 @@ public class SpringSecurityConfig {
     private RequestMatcher[] AuthRequestMatchers() {
         List<RequestMatcher> requestMatchers = List.of(
                 antMatcher(PATCH, "/member/{memberId}"),                // 회원 정보 수정
+                antMatcher(PUT, "/member/{memberId}/password"),        // 비밀번호 재설정
                 antMatcher(DELETE, "/member/{memberId}"),                // 회원 탈퇴
                 antMatcher(POST, "/stores"),                            // 가게 등록
                 antMatcher(POST, "/stores/{storeId}/products"),                // 상품 등록
@@ -148,9 +150,9 @@ public class SpringSecurityConfig {
                 antMatcher(POST, "/member/refresh"), // 엑세스 토큰 갱신
                 antMatcher(DELETE, "/reservations/**"), // 주문 삭제
 
-                antMatcher(GET,"/reservations/done"), // 고객 주문 완료 내역
-                antMatcher(GET,"/reservations/proceeding"), // 고객 진행 중인 주문 내역
-                antMatcher(GET,"/member/registration/token"), // 고객 기기 등록 토큰 등록
+                antMatcher(GET, "/reservations/done"), // 고객 주문 완료 내역
+                antMatcher(GET, "/reservations/proceeding"), // 고객 진행 중인 주문 내역
+                antMatcher(GET, "/member/registration/token"), // 고객 기기 등록 토큰 등록
                 // Review
                 antMatcher(POST, "/reviews/**"),
                 antMatcher(GET, "/reviews/**"),


### PR DESCRIPTION
## 📝 작업 내용
162번과 겹치는 내용이 있어, 162번에서 브랜치를 땄습니다.
164 -> rebase merge -> 162 -> squash merge -> dev 하려고 합니다.

- 비밀번호 재설정 API 추가
  - 프론트에서 이메일 인증 완료후 요청했다는 것을 전제
  - 비밀번호 재설정시 비밀번호 확인란도 함께 검증 (프론트와 이중 검증)
  - 관리자이거나, 본인인경우 비밀번호 재설정 가능 
  - 응답은 204(no content)

## 💬 ETC.
<img width="1277" alt="image" src="https://github.com/backtothefuture-team/backtothefuture-backend/assets/67352902/facb0f0e-d2c9-4f25-9aa2-ce86ff7746a3">


## #️⃣ 연관된 이슈
resolves: #164