### PR TITLE
docs: 주문 내역 스웨거 문서 수정

### DIFF
--- a/api/store/src/main/java/com/backtothefuture/store/dto/response/MemberDoneReservationListDto.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/response/MemberDoneReservationListDto.java
@@ -3,7 +3,6 @@ package com.backtothefuture.store.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -21,6 +20,6 @@ public class MemberDoneReservationListDto {
     private LocalDateTime reservationTime;
     @Schema(description = "주문 전체 금액입니다.")
     private Integer totalPrice;
-    @Schema(description = "예약(주문) 상품 이름입니다. 'productName : 이름' 형태입니다. json key 값은 productName 입니다.")
-    private List<Map<String, String>> productNames;
+    @Schema(description = "예약(주문) 상품 이름 목록입니다.")
+    private List<ReservationProductNameResponseDto> productNames;
 }

--- a/api/store/src/main/java/com/backtothefuture/store/dto/response/MemberProgressReservationResponseDto.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/response/MemberProgressReservationResponseDto.java
@@ -21,13 +21,8 @@ public class MemberProgressReservationResponseDto {
     private LocalDateTime reservationTime;
     @Schema(description = "주문 총 금액입니다.")
     private Integer totalPrice;
-    @Schema(description = "예약(주문) 상품 이름입니다. 'productName : 이름' 형태입니다. json key 값은 productName 입니다.")
-    private List<Map<String, String>> productNames;
-    @Schema(description = "주문 진행 내역입니다. json key 값은"
-            + "REGISTRATION, // 예약 접수\n"
-            + "CONFIRMATION, // 예약 확정\n"
-            + "PICKUP_WAITING, // 픽업 대기\n"
-            + "PICKUP_DONE; // 픽업 완료\n"
-            + "중 하나입니다.")
-    private List<Map<String, LocalDateTime>> reservationHistory;
+    @Schema(description = "예약(주문) 상품 이름 목록입니다.")
+    private List<ReservationProductNameResponseDto> productNames;
+    @Schema(description = "주문 진행 내역입니다.")
+    private List<ProgressReservationHistoryResponseDto> reservationHistories;
 }

--- a/api/store/src/main/java/com/backtothefuture/store/dto/response/ProgressReservationHistoryResponseDto.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/response/ProgressReservationHistoryResponseDto.java
@@ -1,0 +1,14 @@
+package com.backtothefuture.store.dto.response;
+
+import com.backtothefuture.domain.reservation.enums.OrderType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "주문 상태 이력 응답 model")
+public record ProgressReservationHistoryResponseDto(
+        @Schema(description = "주문 상태 종류")
+        OrderType orderType,
+        @Schema(description = "시간")
+        LocalDateTime eventTime
+) {
+}

--- a/api/store/src/main/java/com/backtothefuture/store/dto/response/ReservationProductNameResponseDto.java
+++ b/api/store/src/main/java/com/backtothefuture/store/dto/response/ReservationProductNameResponseDto.java
@@ -1,0 +1,10 @@
+package com.backtothefuture.store.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "완료/진행 중 주문 내역의 상품 이름 응답 model")
+public record ReservationProductNameResponseDto(
+        @Schema(description = "상품 이름")
+        String productName
+) {
+}

--- a/api/store/src/main/java/com/backtothefuture/store/service/ReservationHistoryService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/ReservationHistoryService.java
@@ -8,6 +8,7 @@ import com.backtothefuture.domain.reservation.repository.ReservationStatusHistor
 import com.backtothefuture.security.service.UserDetailsImpl;
 import com.backtothefuture.store.dto.response.MemberDoneReservationResponseDto;
 import com.backtothefuture.store.dto.response.MemberProgressReservationResponseDto;
+import com.backtothefuture.store.dto.response.ProgressReservationHistoryResponseDto;
 import com.backtothefuture.store.dto.response.ReservationListResponseDto;
 import com.backtothefuture.store.dto.response.MemberDoneReservationListDto;
 import com.backtothefuture.store.dto.response.ReservationProductNameResponseDto;
@@ -15,7 +16,6 @@ import com.backtothefuture.store.exception.ReservationException;
 import com.backtothefuture.store.repository.ReservationPagingRepository;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -91,24 +91,30 @@ public class ReservationHistoryService {
 
         memberReservations
                 .forEach(dto -> {
+
+                    List<ReservationProductNameResponseDto> productNames = reservationPagingRepository.getProductsByReservationId(
+                                    dto.reservationId())
+                            .stream()
+                            .map(Product::getName)
+                            .map(ReservationProductNameResponseDto::new)
+                            .collect(Collectors.toList());
+
+                    List<ProgressReservationHistoryResponseDto> reservationHistories = reservationStatusHistoryRepository.findByReservationId(
+                                    dto.reservationId())
+                            .stream()
+                            .map(entity ->
+                                    new ProgressReservationHistoryResponseDto(entity.getOrderType(),
+                                            entity.getEventTime()))
+                            .collect(Collectors.toList());
+
                     response.add(MemberProgressReservationResponseDto.builder()
                             .storeImg(dto.storeImg())
                             .name(dto.name())
                             .reservationId(dto.reservationId())
                             .reservationTime(dto.reservationTime())
                             .totalPrice(dto.totalPrice())
-                            .productNames(
-                                    reservationPagingRepository.getProductsByReservationId(dto.reservationId())
-                                            .stream()
-                                            .map(Product::getName)
-                                            .map(str -> Map.of(PRODUCT_NAME, str))
-                                            .collect(Collectors.toList()))
-                            .reservationHistory(
-                                    reservationStatusHistoryRepository.findByReservationId(dto.reservationId())
-                                            .stream()
-                                            .map(entity ->
-                                                    Map.of(entity.getOrderType().name(), entity.getEventTime()))
-                                            .collect(Collectors.toList()))
+                            .productNames(productNames)
+                            .reservationHistories(reservationHistories)
                             .build());
                 });
 

--- a/api/store/src/main/java/com/backtothefuture/store/service/ReservationHistoryService.java
+++ b/api/store/src/main/java/com/backtothefuture/store/service/ReservationHistoryService.java
@@ -10,6 +10,7 @@ import com.backtothefuture.store.dto.response.MemberDoneReservationResponseDto;
 import com.backtothefuture.store.dto.response.MemberProgressReservationResponseDto;
 import com.backtothefuture.store.dto.response.ReservationListResponseDto;
 import com.backtothefuture.store.dto.response.MemberDoneReservationListDto;
+import com.backtothefuture.store.dto.response.ReservationProductNameResponseDto;
 import com.backtothefuture.store.exception.ReservationException;
 import com.backtothefuture.store.repository.ReservationPagingRepository;
 import java.util.ArrayList;
@@ -54,18 +55,21 @@ public class ReservationHistoryService {
 
             memberProceedingReservations.getContent()
                     .forEach(dto -> {
+
+                        List<ReservationProductNameResponseDto> productNames = reservationPagingRepository.getProductsByReservationId(
+                                        dto.reservationId())
+                                .stream()
+                                .map(Product::getName)
+                                .map(ReservationProductNameResponseDto::new)
+                                .collect(Collectors.toList());
+
                         response.add(MemberDoneReservationListDto.builder()
                                 .storeImg(dto.storeImg())
                                 .name(dto.name())
                                 .reservationId(dto.reservationId())
                                 .reservationTime(dto.reservationTime())
                                 .totalPrice(dto.totalPrice())
-                                .productNames(
-                                        reservationPagingRepository.getProductsByReservationId(dto.reservationId())
-                                                .stream()
-                                                .map(Product::getName)
-                                                .map(str -> Map.of(PRODUCT_NAME, str))
-                                                .collect(Collectors.toList()))
+                                .productNames(productNames)
                                 .build());
                     });
 


### PR DESCRIPTION
## 📝 작업 내용
 - 진행 중인 주문 내역, 주문 완료 내역 API 문서화를 수정했습니다.
   - 기존에 실제 반환 값과 다른 json key가 스웨거 example value에 표시되었는데 이를 아래와 같이 수정했습니다.
   - 진행 중인 주문 내역
   
![image](https://github.com/backtothefuture-team/backtothefuture-backend/assets/108208265/ed6ea380-125a-4123-9339-ad6b15a212f1)
  - 주문 완료 내역
  
![image](https://github.com/backtothefuture-team/backtothefuture-backend/assets/108208265/5f0cfe94-41f3-43c0-93b5-b35d49316781)
 

## 💬 ETC.
 - **기타 공유사항에 대해 작성해 주세요.**

## #️⃣ 연관된 이슈
resolves: #178 